### PR TITLE
Add project architecture and development documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,47 @@
+# SAD2XS documentation
+
+This folder contains the project documentation for SAD2XS.
+
+The documentation is intended to define the structure, assumptions, and development conventions used by the project. It should make converter changes easier to review and help ensure that new behaviour is consistent with the intended architecture.
+
+Some sections describe current behaviour. Others describe agreed direction for upcoming work. Where this distinction matters, the relevant page should state it explicitly.
+
+## Documentation convention
+
+When a section describes behaviour that is not yet implemented, it should use one of these labels:
+
+- `Current status`: what the code does today.
+- `Next release target`: behaviour expected before the next release is complete.
+- `Long-term direction`: design direction that is useful to record but not required for the next release.
+
+Avoid describing target behaviour as if it already exists.
+
+## Contents
+
+- [Architecture](architecture.md): package layout, subsystem responsibilities, and boundaries between parser, converter, writer, and SAD helper code.
+- [Conversion model](conversion-model.md): the SAD-to-Xsuite conversion pipeline and the decision to treat the converted Xsuite model as the canonical representation.
+- [SAD helpers](sad-helpers.md): Python wrappers around external SAD calculations, including entry points, subprocess handling, timeouts, optionality target, and current limitations.
+- [Testing](testing.md): public test policy, local validation rules, temporary file handling, and expected regression test structure.
+- [Contributing](contributing.md): branch naming, pull request expectations, release workflow, and public issue policy.
+- [Design decisions](design-decisions.md): project-level decisions that should guide future development.
+
+## Scope
+
+These documents currently cover:
+
+- converter architecture and responsibility boundaries;
+- the role of Xsuite as the canonical intermediate model;
+- SAD helper functionality and its current subprocess model;
+- testing policy for public and private validation;
+- contribution and release workflow for the current development cycle;
+- design decisions that affect future converter, writer, and helper changes.
+
+These documents do not yet cover:
+
+- a complete user guide;
+- full installation instructions;
+- generated API documentation;
+- a complete reference for every supported SAD element;
+- detailed examples for every conversion mode.
+
+Those sections should be added as the public API, docstrings, and supported conversion behaviours are stabilised.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,108 @@
+# Architecture
+
+SAD2XS converts SAD lattice descriptions into Xsuite objects and can write Python files that rebuild the converted model.
+
+The current package is organised as a single project with several internal subsystems:
+
+```text
+SAD input
+  -> parser and expression handling
+  -> element filtering and conversion
+  -> Xsuite Environment and Line construction
+  -> post-conversion corrections and line operations
+  -> output writer
+```
+
+The module numbering inside `sad2xs/converter/` reflects the historical pipeline order. It is useful for navigation, but it should not be treated as a public API promise.
+
+## Top-level orchestration
+
+`sad2xs/main.py` is the main orchestration layer. The public conversion entry point is `convert_sad_to_xsuite`.
+
+The current orchestration flow is:
+
+```text
+parse SAD input
+  -> exclude requested elements
+  -> optionally convert apertures to markers
+  -> create an Xsuite Environment
+  -> convert expressions and globals
+  -> create the reference particle
+  -> convert elements
+  -> convert lines
+  -> select the requested or longest line
+  -> apply solenoid and harmonic RF corrections
+  -> configure element models and integrators
+  -> apply requested line and charge reversals
+  -> install offset markers
+  -> write lattice and optics files
+  -> reload the generated files and return the rebuilt line
+```
+
+When `_test_mode=True`, the function returns the converted line before writing and reloading output files.
+
+Next release target: this layer should stay thin where possible. Conversion details should live in converter modules, writer details should live in output writer modules, and external SAD helper logic should stay separate.
+
+## Public import surface
+
+The current top-level package import exposes:
+
+- `convert_sad_to_xsuite`;
+- `write_lattice`;
+- `write_optics`;
+- `sad_helpers`.
+
+This is the practical public surface today.
+
+Next release target: future changes should reduce import-time coupling to `sad_helpers`, because helper functionality depends on an external SAD installation and additional Python packages.
+
+## Configuration and shared types
+
+`sad2xs/config.py` stores conversion settings and defaults.
+
+`sad2xs/types.py` contains shared type aliases used across the converter and writer. Shared structures should remain small and explicit. They should not become a second hidden lattice model that competes with Xsuite.
+
+## Converter subsystem
+
+The converter modules in `sad2xs/converter/` are responsible for turning parsed SAD information into Xsuite objects.
+
+Key responsibilities:
+
+- `_001_parser.py`: parse SAD file content into structured sections.
+- `_002_element_exclusion.py`: remove or skip elements that should not be converted directly.
+- `_003_expression_converter.py`: translate SAD-style expressions into Python-compatible expressions.
+- `_004_element_converter.py`: convert supported SAD element definitions into Xsuite elements.
+- `_005_line_converter.py`: convert SAD line definitions into Xsuite line definitions.
+- `_006_solenoid_converter.py`: handle solenoid-specific conversion details.
+- `_007_harmonic_rf.py`: handle harmonic RF cases.
+- `_008_reversals.py`: construct reversed elements and lines where needed.
+- `_009_offset_markers.py`: install offset marker structures.
+- `_010_write_lattice.py` and `_011_write_optics.py`: writer entry points that assemble output from the `sad2xs/output_writer/` modules.
+
+Next release target: the converter should produce a valid Xsuite model and should not rely on the writer to repair conversion semantics.
+
+## Output writer subsystem
+
+The output writer modules in `sad2xs/output_writer/` generate Python lattice and optics files from the converted Xsuite model.
+
+Current status: the writer accepts an `xt.Line` at the main `write_lattice` entry point and can fill some missing global variables from `line.particle_ref`.
+
+Long-term direction: the writer should become a more complete reusable serializer for Xsuite lattices, not only the final step of a SAD2XS conversion. This matters because a user may rematch or modify an Xsuite lattice after conversion and still want readable SAD2XS-style output.
+
+Next release target: writer output should prefer information from the Xsuite `Environment`, `Line`, and element objects over raw SAD data. Any remaining dependency on SAD-specific conversion context should be explicit.
+
+## SAD helper subsystem
+
+The modules in `sad2xs/sad_helpers/` call external SAD tools for operations such as tracking, survey, twiss, transfer matrix, emittance, and chromaticity calculations.
+
+These helpers are valuable for validation and comparison, but they depend on an external SAD installation.
+
+Current status: the top-level package re-exports `sad_helpers`, so import-time coupling to helper dependencies may still exist.
+
+Next release target: importing and using the core converter should not require SAD helper dependencies to be available.
+
+## Public and private validation
+
+The repository may be validated against private or non-shareable lattices during development. Those lattices must not be required for public tests or CI, and public issues should use synthetic reproductions.
+
+Public regression tests should isolate the converter behaviour being protected without depending on private accelerator files.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,83 @@
+# Contributing
+
+This document records the development workflow used for the current release cycle.
+
+## Branch model
+
+`main` is the stable branch.
+
+`release/x.y.z` is the integration branch for the next planned release, where `x.y.z` is the version being prepared.
+
+Issue branches should be created from the active release branch and should normally be merged back into that release branch by pull request.
+
+For example, while preparing version `0.3.0`, the active release branch would be `release/0.3.0`.
+
+Recommended branch naming:
+
+```text
+docs/24-architecture-and-conversion-model
+test/20-public-test-baseline
+fix/26-verbose-logging-only
+feature/30-comma-separated-lines
+```
+
+Use the issue number when one exists. Keep names descriptive enough that the branch purpose is clear in GitHub and local tooling.
+
+Before starting work, make sure the working tree is clean and the issue branch is based on the active release branch.
+
+## Pull requests
+
+Pull requests should:
+
+- target the active release branch during the current release cycle;
+- link the relevant issue;
+- keep changes scoped to one issue where practical;
+- include tests for behaviour changes;
+- update documentation when behaviour, architecture, or workflow changes;
+- avoid unrelated formatting churn;
+- avoid public references to private or non-shareable lattices.
+
+If a change is discovered to be larger than expected, split it into smaller pull requests before review becomes difficult.
+
+## Releases and tags
+
+GitHub releases and version tags should be used for actual published versions, not for temporary development branches.
+
+Do not tag issue branches or intermediate cleanup states. When the active release branch is complete, it should be merged to `main`, tagged as the released version, and published as a GitHub release.
+
+Before publishing a package release, update all package version metadata to the released version. At minimum, check `setup.py`; if future packaging files are added, such as `pyproject.toml` or a dedicated version module, they must be updated consistently as part of the release branch before tagging.
+
+## Commit style
+
+Commit messages should be short and specific.
+
+Examples:
+
+```text
+Fix verbose flag changing aperture conversion
+Add parser regression tests for comma-separated lines
+Document Xsuite model as canonical conversion layer
+```
+
+## Environment
+
+Use the `xsuite` conda environment for Python commands:
+
+```bash
+conda run -n xsuite pytest
+conda run -n xsuite python -m pytest tests/test_001_drift.py
+```
+
+For documentation-only changes, Python tests are not normally required unless examples or generated outputs are changed.
+
+GitHub CLI commands can also be run from the same environment when needed:
+
+```bash
+conda run -n xsuite gh issue list
+```
+
+## Public issue policy
+
+Issues should describe shareable behaviour.
+
+If a private lattice exposes a bug, the public issue should describe the minimal public reproduction or the general converter feature that is missing. Do not include private lattice files, private names, or machine-specific details that are not shareable.

--- a/docs/conversion-model.md
+++ b/docs/conversion-model.md
@@ -1,0 +1,89 @@
+# Conversion model
+
+The core SAD2XS design choice is that Xsuite is the canonical intermediate representation.
+
+SAD input is parsed and converted into Xsuite objects.
+
+Next release target: after conversion, the Xsuite `Environment`, `Line`, and element objects should be the source of truth for writer output and later processing.
+
+## Why Xsuite is canonical
+
+Raw SAD definitions are not always authoritative after conversion.
+
+Reasons include:
+
+- SAD line reversals may require derived or transformed Xsuite elements.
+- Conversion may expand one SAD concept into several Xsuite elements or helper markers.
+- Offsets, apertures, and solenoid handling may require Xsuite-specific structures.
+- Users may later rematch or modify the Xsuite lattice and still want readable regenerated outputs.
+- Current Xsuite APIs can change, so the converter must target the active Xsuite object model rather than preserve stale SAD syntax.
+
+For these reasons, SAD2XS should not treat parsed SAD text as the primary model once conversion has happened.
+
+## Conversion pipeline
+
+```text
+1. Read SAD file content.
+2. Normalize names and simple whitespace.
+3. Parse constants, globals, elements, and lines.
+4. Exclude user-requested elements.
+5. Optionally convert aperture elements to markers.
+6. Create an Xsuite Environment and populate variables.
+7. Create the Xsuite reference particle.
+8. Convert supported SAD elements to Xsuite elements.
+9. Convert SAD line definitions to Xsuite lines.
+10. Select the requested line, or the longest available line.
+11. Apply solenoid-specific corrections.
+12. Apply harmonic RF handling.
+13. Configure models, integrators, and bend edge handling.
+14. Apply requested line order, bend direction, and charge reversals.
+15. Install offset markers.
+16. Write lattice and optics files from the Xsuite model.
+17. Reload the generated files and return the rebuilt Xsuite line.
+```
+
+This describes the current high-level orchestration. Some individual steps need cleanup to fully satisfy the design decisions in this documentation.
+
+## Parser expectations
+
+Next release target: the parser should turn SAD text into structured data without losing information that later conversion stages need.
+
+Important parser expectations for the next release include:
+
+- comments should not affect semicolon-based section splitting;
+- globals and expressions should be available to later element conversion;
+- SAD functions should be resolved in a controlled and testable way;
+- line definitions should support supported SAD syntax variants, including comma-separated components;
+- arithmetic in element parameters should not depend on fragile whitespace handling.
+
+## Element conversion expectations
+
+Next release target: element conversion should preserve the physics information that Xsuite can represent.
+
+Important cases for the next release include:
+
+- RF cavities should use the current Xsuite phase and harmonic conventions.
+- Coordinate transforms should use current Xsuite transform elements such as translations, rotations, and time delays.
+- Thin and zero-length magnetic elements need a documented policy, likely using `xt.Multipole` where appropriate.
+- Combined multipole components should be preserved when a base element includes higher-order corrections.
+- Aperture conversion should support equivalent SAD aperture parameter forms where the meaning is clear.
+
+Unsupported cases should fail clearly. Silent loss of physics information is worse than a loud error.
+
+## Writer expectations
+
+Next release target: the writer should serialize the Xsuite model that SAD2XS actually built.
+
+This means:
+
+- writer output should reflect converted and reversed Xsuite elements;
+- writer output should not require the original SAD text to remain authoritative;
+- regenerated lattices should compile and reproduce the intended Xsuite model;
+
+Long-term direction: the writer should accept a general Xsuite line or environment, not only a direct SAD2XS conversion result.
+
+## Boundaries
+
+SAD2XS is not expected to preserve every SAD syntax detail. It is expected to preserve the accelerator model within the limits of supported Xsuite elements and documented conversion rules.
+
+Where SAD and Xsuite have different physics models or naming conventions, the converter should document the choice and test the expected behaviour with synthetic examples.

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -1,0 +1,53 @@
+# Design decisions
+
+This file is a lightweight decision log. It records project-level choices that should guide future changes.
+
+## Xsuite is the canonical intermediate model
+
+Decision: after SAD input is parsed and converted, Xsuite objects are the source of truth.
+
+Reasoning: SAD input may not represent the final converted model after reversals, substitutions, offsets, apertures, solenoid handling, or user rematching. Writing outputs from the Xsuite model keeps the writer aligned with what the converter actually built.
+
+Consequence: new converter features should assert on the Xsuite model where possible. Writer changes should avoid depending on raw SAD text unless there is a documented reason.
+
+## Public tests must be shareable
+
+Decision: public tests must use synthetic or publicly shareable inputs.
+
+Reasoning: the repository and CI should be usable by contributors who do not have access to private lattices.
+
+Consequence: private validation can still be used locally, but public bugs should be reduced to small synthetic reproductions before tests or issues are added.
+
+## SAD helpers are optional
+
+Decision: external SAD helper functionality should remain optional for the core converter.
+
+Reasoning: helper functions are useful for validation and comparison, but they depend on an external SAD installation. Users should be able to import and use the converter without setting up every helper dependency.
+
+Consequence: helper imports should not make core conversion imports fail. Tests that require external SAD should skip cleanly when SAD is unavailable.
+
+Current status: this is not fully implemented. The top-level package still re-exports `sad_helpers`, so import-time coupling should be reduced in a future packaging change.
+
+## Keep SAD2XS as one package for now
+
+Decision: do not split the project into separate SAD helper and SAD-to-Xsuite packages during the current release cycle.
+
+Reasoning: the current priority is converter correctness, public tests, and writer clarity. A package split would add release and dependency complexity before the internal boundaries are stable.
+
+Consequence: keep boundaries clear inside the current package. If the SAD helper layer becomes independently useful and testable, a future package split can be reconsidered.
+
+## Writer should become reusable
+
+Decision: the long-term writer direction is a reusable Xsuite serializer.
+
+Reasoning: users may want to convert a SAD lattice, rematch or modify it in Xsuite, then regenerate readable lattice and optics files. That workflow should not require the original SAD input to remain the authoritative source.
+
+Consequence: writer APIs should move toward accepting complete Xsuite lines or environments. The current writer already accepts an `xt.Line` for lattice output, but it still carries SAD2XS-specific assumptions that need to be documented and reduced.
+
+## Configuration must not change semantics accidentally
+
+Decision: diagnostic options such as verbosity should affect logging only, unless a setting is explicitly documented as changing conversion behaviour.
+
+Reasoning: users need repeatable conversion results. A flag intended for observability should not silently enable or disable conversion steps.
+
+Consequence: behaviour-affecting settings must be documented and tested. Logging settings should be tested to ensure they do not alter the converted Xsuite model.

--- a/docs/sad-helpers.md
+++ b/docs/sad-helpers.md
@@ -1,0 +1,140 @@
+# SAD helpers
+
+The `sad2xs.sad_helpers` package contains Python wrappers around external SAD calculations.
+
+These helpers are separate from the core SAD-to-Xsuite converter. They are used for comparison, validation, and workflows where SAD remains useful alongside the converted Xsuite model.
+
+Current status: the top-level package imports `sad_helpers`, so full import-time decoupling is not complete.
+
+Next release target: these helpers should remain optional relative to the core SAD-to-Xsuite converter.
+
+## Requirements
+
+The helper functions require:
+
+- a working SAD executable;
+- input lattice files that SAD can read;
+- Python dependencies used by the helper being called, such as `numpy`, `tfs`, `xtrack`, and `tqdm`;
+- a writable current working directory for temporary command and output files.
+
+By default the helpers call an executable named `sad`. A different executable path can be passed with the `sad_path` argument.
+
+## Public helper functions
+
+The following functions are re-exported from `sad2xs.sad_helpers`:
+
+- `rebuild_sad_lattice`: load a SAD lattice, optionally apply additional SAD commands, and write a rebuilt SAD file.
+- `twiss_sad`: run SAD Twiss and return an Xsuite-style `TwissTable`.
+- `survey_sad`: run SAD survey-style output and return an Xsuite-style survey table.
+- `emit_sad`: run SAD emittance calculation and return parsed emittance information.
+- `track_sad`: track particles in SAD and return particle coordinates.
+- `transfer_matrix_sad`: compute a SAD transfer matrix for a full line or an element range.
+- `chromaticity_sad`: scan off-momentum tunes and fit chromaticities.
+- `compute_chromatic_functions`: compute chromatic functions by finite differences around a SAD Twiss calculation.
+- `compute_second_order_dispersions`: compute second-order dispersions by finite differences around a SAD Twiss calculation.
+
+## Typical use from Python
+
+```python
+from sad2xs.sad_helpers import twiss_sad, track_sad
+
+tw = twiss_sad(
+    lattice_filepath="path/to/lattice.sad",
+    line_name="RING",
+    closed=True,
+    wall_time=60,
+    sad_path="sad",
+)
+```
+
+Tracking uses NumPy arrays for the initial particle coordinates:
+
+```python
+import numpy as np
+from sad2xs.sad_helpers import track_sad
+
+result = track_sad(
+    lattice_filepath="path/to/lattice.sad",
+    line_name="RING",
+    x_init=np.array([0.0]),
+    px_init=np.array([0.0]),
+    y_init=np.array([0.0]),
+    py_init=np.array([0.0]),
+    zeta_init=np.array([0.0]),
+    delta_init=np.array([0.0]),
+    n_turns=10,
+    wall_time=120,
+    sad_path="sad",
+)
+```
+
+## Additional SAD commands
+
+Several helpers accept `additional_commands`.
+
+This argument is inserted into the generated SAD command after the lattice is loaded and the line is selected. It can be used for local optics changes, rematching commands, or other SAD-side setup before the calculation is run.
+
+Use this argument carefully. It is raw SAD command text and is not validated by SAD2XS.
+
+## Timeout handling
+
+Most helpers use `subprocess.run(..., timeout=wall_time, check=True)`.
+
+Current behaviour:
+
+- if SAD exceeds `wall_time`, Python raises `subprocess.TimeoutExpired`;
+- if SAD exits with a non-zero status, Python raises `subprocess.CalledProcessError`;
+- stdout and stderr are printed for non-zero exits where available;
+- known temporary command files are removed in the handled timeout and error paths for most helpers.
+
+`track_sad` uses `subprocess.Popen` so that progress can be read while SAD is running. It checks elapsed wall time while reading SAD output, kills the process on timeout, and raises `TimeoutError`. This timeout approach is less robust if SAD stops producing output while still running.
+
+Default wall times are currently short for optics-style helpers and longer for tracking:
+
+- most optics helpers default to `wall_time=30` seconds;
+- `chromaticity_sad` defaults to `wall_time=60` seconds;
+- `track_sad` defaults to `wall_time=24*60*60` seconds.
+
+## Temporary files
+
+The helpers currently write fixed temporary filenames in the current working directory, for example:
+
+- `temp_sad_twiss.sad`
+- `temp_sad_twiss.tfs`
+- `temp_sad_survey.sad`
+- `temp_sad_survey.tfs`
+- `temp_sad_track.sad`
+- `temp_sad_track.dat`
+- `temp_sad_emit.sad`
+- `temp_sad_tmatrix.sad`
+- `temp_sad_chromaticity.sad`
+- `temp_sad_rebuild_lattice.sad`
+
+This means helper calls should not be run concurrently from the same working directory. It also means failed or interrupted processes may leave temporary files behind.
+
+Next release target: move these helpers to isolated temporary directories, preferably using Python temporary directory APIs or pytest `tmp_path` in tests.
+
+## Current safeguards
+
+The helper layer currently provides these safeguards:
+
+- `wall_time` limits for external SAD calls;
+- `check=True` for most subprocess calls, so non-zero SAD exits are treated as failures;
+- cleanup of known temporary command files on many normal, timeout, and handled error paths;
+- array shape and size assertions in `track_sad`;
+- explicit validation that `transfer_matrix_sad` receives either both `start_element` and `end_element`, or neither.
+
+## Current limitations
+
+Known limitations:
+
+- helper imports and execution depend on optional runtime dependencies;
+- top-level package import still re-exports the helper package;
+- temporary files use fixed names in the current working directory;
+- helper calls are not safe to run concurrently from the same directory;
+- `additional_commands` is raw SAD text and is not sandboxed or validated;
+- subprocess output parsing is tailored to the current generated SAD commands;
+- cleanup is not guaranteed for every interrupted or unexpected failure path;
+- some error messages still use generic wording from earlier Twiss-only implementations.
+
+Next release target: address these limitations incrementally without making the core converter depend on an external SAD installation.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,81 @@
+# Testing
+
+Testing should protect converter behaviour while keeping the public repository shareable and maintainable.
+
+All Python commands should be run inside the `xsuite` conda environment unless there is a specific reason not to:
+
+```bash
+conda run -n xsuite pytest
+```
+
+## Public test policy
+
+Public tests must use synthetic or publicly shareable inputs.
+
+Private or non-shareable lattices can be used for local validation, but they must not be required for public CI, public issues, or public regression tests. If a private lattice reveals a bug, reduce it to a small synthetic SAD example before adding a public test.
+
+Public tests should not mention private lattice names or institution-specific files unless those files are explicitly public and committed to the repository.
+
+Public examples may use committed public lattices. Regression tests for bugs found in private validation should use reduced synthetic inputs.
+
+## Test layers
+
+Next release target: the test suite should cover several layers:
+
+- Parser tests for comments, section splitting, line syntax, expressions, globals, and functions.
+- Element conversion tests for one SAD element or one feature at a time.
+- Line construction tests for line composition, repeated elements, and reversed lines.
+- Writer tests that verify generated outputs compile and rebuild the intended Xsuite model.
+- SAD helper tests that are optional or clearly skipped when an external SAD installation is unavailable.
+
+Large end-to-end lattice tests are useful, but they should not be the only protection. Small regression tests make failures easier to understand.
+
+Current status: the test suite includes several larger conversion checks and some placeholder files.
+
+Next release target: keep the useful larger checks while adding smaller, more targeted regression tests.
+
+## Temporary files
+
+Next release target: tests should use isolated temporary directories, preferably pytest `tmp_path`, for generated SAD files, output files, and helper scripts.
+
+Tests should not write generated files into the repository root, `tests/`, `lattice_tests/`, or committed output folders unless the test is explicitly updating a tracked fixture.
+
+Current status: some tests and helper utilities still write fixed temporary files or output plots into repository paths.
+
+## Physics edge cases
+
+Edge cases should be tested when they protect real converter behaviour.
+
+Examples include:
+
+- unusual but valid angles and rotations;
+- zero-length or thin elements;
+- combined multipole components;
+- reversed lines and reversed elements;
+- aperture aliases and equivalent parameter forms;
+- RF phase and harmonic conventions.
+
+The default baseline tests should remain simple. Extreme values should be isolated in targeted tests so they do not obscure unrelated failures.
+
+## Regression test rule
+
+Next release target: every converter bug fix should add or update a test unless there is a clear reason not to.
+
+The preferred pattern is:
+
+```text
+1. Add a minimal synthetic SAD input that reproduces the issue.
+2. Convert it through the public API.
+3. Assert on the Xsuite object model.
+4. If relevant, write and reload the generated output.
+```
+
+Tests should assert behaviour, not implementation details, unless the implementation detail is itself part of the documented contract.
+
+For parser fixes, asserting the parsed structure is appropriate. For converter fixes, asserting on the Xsuite objects is usually better than asserting on intermediate dictionaries.
+
+## CI expectations
+
+Next release target: CI should run the public test suite without private files or local machine assumptions.
+
+External SAD-dependent tests should either be skipped when SAD is unavailable or run in a separate job that clearly declares the dependency.


### PR DESCRIPTION
Adds initial project documentation covering architecture, conversion model, SAD helpers, testing policy, contribution workflow, and design decisions.

Closes #24.