### PR TITLE
Raise clear error for thin multipole replacements

### DIFF
--- a/sad2xs/converter/_004_element_converter.py
+++ b/sad2xs/converter/_004_element_converter.py
@@ -837,10 +837,10 @@ def convert_multipoles(
                 replace_type    = None
 
                 if not "l" in ele_vars:
-                    print(
-                        f"Warning! Multipole {ele_name} is a thin lens" +\
-                        "replacement not supported for thin lens")
-                    continue
+                    raise TypeError(
+                        f"Warning! Multipole {ele_name} is thin.\n" + \
+                        "Replacement is not supported for thin elements.\n" + \
+                        "Remove this from the multipole replacements to continue")
 
                 # Search the multipole replacements dict for the type of element
                 for replacement in user_multipole_replacements:

--- a/sad2xs/converter/_004_element_converter.py
+++ b/sad2xs/converter/_004_element_converter.py
@@ -836,16 +836,19 @@ def convert_multipoles(
             if any(ele_name.startswith(test_key) for test_key in user_multipole_replacements):
                 replace_type    = None
 
-                if not "l" in ele_vars:
-                    raise TypeError(
-                        f"Warning! Multipole {ele_name} is thin.\n" + \
-                        "Replacement is not supported for thin elements.\n" + \
-                        "Remove this from the multipole replacements to continue")
-
                 # Search the multipole replacements dict for the type of element
                 for replacement in user_multipole_replacements:
                     if ele_name.startswith(replacement):
                         replace_type    = user_multipole_replacements[replacement]
+
+                if "l" not in ele_vars or \
+                    (isinstance(length, (float, int)) and abs(length) <= config.KNL_ZERO_TOL):
+                    raise ValueError(
+                        f"Cannot replace thin SAD multipole {ele_name} with {replace_type}.\n" + \
+                        "Multipole replacement requires a non-zero length because integrated " + \
+                        "strengths must be divided by length.\n" + \
+                        "Remove this element from user_multipole_replacements or leave it as " + \
+                        "an xt.Multipole.")
 
                 ########################################
                 # Bend Replacement (kick)

--- a/tests/test_006_mult_TBD.py
+++ b/tests/test_006_mult_TBD.py
@@ -1,0 +1,44 @@
+"""
+(Unofficial) SAD to XSuite Converter
+
+Tests for SAD MULT conversion.
+"""
+
+################################################################################
+# Required Packages
+################################################################################
+import pytest
+import xtrack as xt
+
+from sad2xs.config import Config
+from sad2xs.converter._004_element_converter import convert_multipoles
+
+################################################################################
+# Thin Multipole Replacement Errors
+################################################################################
+@pytest.mark.parametrize(
+    "element_variables",
+    [
+        {"k1": "0.01"},
+        {"l": "0", "k1": "0.01"},
+    ])
+def test_thin_multipole_replacement_raises_clear_error(element_variables):
+    """
+    A thin SAD MULT cannot currently be replaced by a thick element type.
+
+    The replacement path divides integrated multipole strengths by the element
+    length. Missing and zero lengths should therefore fail before any division is
+    attempted.
+    """
+    parsed_elements = {
+        "mult": {
+            "test_mult": element_variables,
+        },
+    }
+
+    with pytest.raises(ValueError, match = "Cannot replace thin SAD multipole"):
+        convert_multipoles(
+            parsed_elements              = parsed_elements,
+            environment                  = xt.Environment(),
+            user_multipole_replacements  = {"test": "Quadrupole"},
+            config                       = Config(_verbose = False))


### PR DESCRIPTION
Makes unsupported thin SAD multipole replacements fail with a clear ValueError instead of printing a warning or dividing by zero. Adds targeted in-memory regression tests for missing and zero-length multipoles.