### PR TITLE
Make verbose flag control converter output only

### DIFF
--- a/sad2xs/converter/_004_element_converter.py
+++ b/sad2xs/converter/_004_element_converter.py
@@ -192,10 +192,12 @@ def convert_elements(
             print_section_heading("Converting Bends", mode = "subsection")
         convert_bends(
             parsed_elements = parsed_elements,
-            environment     = environment)
+            environment     = environment,
+            config          = config)
         convert_correctors(
             parsed_elements = parsed_elements,
-            environment     = environment)
+            environment     = environment,
+            config          = config)
 
     ########################################
     # Quadrupoles
@@ -225,7 +227,8 @@ def convert_elements(
             print_section_heading("Converting Octupoles", mode = "subsection")
         convert_octupoles(
             parsed_elements = parsed_elements,
-            environment     = environment)
+            environment     = environment,
+            config          = config)
 
     ########################################
     # Multipoles
@@ -247,7 +250,8 @@ def convert_elements(
             print_section_heading("Converting Cavities", mode = "subsection")
         convert_cavities(
             parsed_elements = parsed_elements,
-            environment     = environment)
+            environment     = environment,
+            config          = config)
 
     ########################################
     # Apertures
@@ -342,7 +346,7 @@ def convert_drifts(parsed_elements, environment):
 ################################################################################
 # Convert Bends
 ################################################################################
-def convert_bends(parsed_elements, environment):
+def convert_bends(parsed_elements, environment, config):
     """
     Convert bends from the SAD parsed data
     """
@@ -362,7 +366,8 @@ def convert_bends(parsed_elements, environment):
                 if k0l != 0:
                     raise ValueError(f"Error! Bend {ele_name} missing length.")
                 else:
-                    print(f"Warning! Bend {ele_name} missing length and installed as marker")
+                    if config._verbose:
+                        print(f"Warning! Bend {ele_name} missing length and installed as marker")
                     environment.new(
                         name                = ele_name,
                         parent              = xt.Marker)
@@ -443,7 +448,7 @@ def convert_bends(parsed_elements, environment):
 ################################################################################
 # Convert Correctors
 ################################################################################
-def convert_correctors(parsed_elements, environment):
+def convert_correctors(parsed_elements, environment, config):
     """
     Convert correctors from the SAD parsed data
     """
@@ -477,7 +482,8 @@ def convert_correctors(parsed_elements, environment):
             shift_x, shift_y, rotation  = get_element_misalignments(ele_vars)
 
             if length == 0:
-                print(f"Warning! Corrector {ele_name} missing length and installed as marker")
+                if config._verbose:
+                    print(f"Warning! Corrector {ele_name} missing length and installed as marker")
 
                 environment.new(
                     name    = ele_name,
@@ -694,7 +700,7 @@ def convert_sextupoles(parsed_elements, environment):
 ################################################################################
 # Convert Octupoles
 ################################################################################
-def convert_octupoles(parsed_elements, environment):
+def convert_octupoles(parsed_elements, environment, config):
     """
     Convert octupoles from the SAD parsed data
     """
@@ -705,7 +711,8 @@ def convert_octupoles(parsed_elements, environment):
 
         if "l" not in ele_vars:
             # TODO: Improve the handling of this
-            print(f"Warning! Octupole {ele_name} missing length and installed as marker")
+            if config._verbose:
+                print(f"Warning! Octupole {ele_name} missing length and installed as marker")
             environment.new(
                 name                = ele_name,
                 parent              = xt.Marker)
@@ -1238,7 +1245,7 @@ def convert_multipoles(
 ################################################################################
 # Convert Cavities
 ################################################################################
-def convert_cavities(parsed_elements, environment):
+def convert_cavities(parsed_elements, environment, config):
     """
     Convert cavities from the SAD parsed data
     """
@@ -1275,7 +1282,7 @@ def convert_cavities(parsed_elements, environment):
             else:
                 raise ValueError(f"Unsupported type for phi offset: {type(phi_offset)}")
 
-        if "harm" in ele_vars:
+        if "harm" in ele_vars and config._verbose:
             print(f"Cavity {ele_name} is harmonic and addressed later")
 
         ########################################
@@ -1856,9 +1863,10 @@ def convert_coordinate_transformations(
             environment.new(
                 name    = ele_name,
                 parent  = xt.XYShift)
-            print(
-                f"Warning! Coordinate transformation {ele_name} has no transformations defined, " +\
-                "installing as XYShift")
+            if config._verbose:
+                print(
+                    f"Warning! Coordinate transformation {ele_name} has no transformations defined, " +\
+                    "installing as XYShift")
             continue
         elif n_transforms == 1:
             if offset_x != 0:

--- a/sad2xs/converter/_005_line_converter.py
+++ b/sad2xs/converter/_005_line_converter.py
@@ -223,5 +223,6 @@ def convert_lines(
         converted_lines.append(line)
 
     if len(converted_lines) < len(parsed_lines):
-        print(f"Converted {len(converted_lines)} lines out of {len(parsed_lines)}")
-        raise ValueError("Not all lines could be converted. Check the input data.")
+        raise ValueError(
+            f"Converted {len(converted_lines)} lines out of {len(parsed_lines)}. "
+            "Not all lines could be converted. Check the input data.")

--- a/sad2xs/converter/_007_harmonic_rf.py
+++ b/sad2xs/converter/_007_harmonic_rf.py
@@ -39,7 +39,8 @@ def convert_harmonic_rf(
 
     has_cavities = "cavi" in parsed_lattice_data["elements"]
     if not has_cavities:
-        print("No cavities in line")
+        if config._verbose:
+            print("No cavities in line")
         return line
 
     has_harmonic_cavities   = any(
@@ -47,7 +48,8 @@ def convert_harmonic_rf(
         for v in parsed_lattice_data["elements"]["cavi"].values())
 
     if not has_harmonic_cavities:
-        print("No harmonic cavities in line")
+        if config._verbose:
+            print("No harmonic cavities in line")
         return line
 
     ########################################

--- a/sad2xs/converter/_009_offset_markers.py
+++ b/sad2xs/converter/_009_offset_markers.py
@@ -143,8 +143,9 @@ def convert_offset_markers(
             # Exclude slicing solenoids
             ########################################
             if isinstance(line[insert_at_ele], xt.UniformSolenoid):
-                print("Slicing Solenoid elements causes issues")
-                print(f"Marker {base_marker} Ignored at {s_to_insert}")
+                if verbose:
+                    print("Slicing Solenoid elements causes issues")
+                    print(f"Marker {base_marker} Ignored at {s_to_insert}")
                 continue
 
         # Produce a dictionary of the s locations that markers are inserted at

--- a/sad2xs/main.py
+++ b/sad2xs/main.py
@@ -82,18 +82,18 @@ def convert_sad_to_xsuite(
     if install_apertures_as_markers:
         if config._verbose:
             print_section_heading("Converting apertures to markers", mode = 'section')
-                    
-            if "apert" in parsed_lattice_data['elements']:
-                if "mark" in parsed_lattice_data['elements']:
-                    merged = {
-                        **parsed_lattice_data['elements']["apert"],
-                        **parsed_lattice_data['elements']["mark"]}    # Mark takes precedence
-                    parsed_lattice_data['elements']["mark"] = merged
-                else:
-                    parsed_lattice_data['elements']["mark"] = \
-                        parsed_lattice_data['elements']["apert"]
-                
-                parsed_lattice_data['elements'].pop("apert")
+
+        if "apert" in parsed_lattice_data['elements']:
+            if "mark" in parsed_lattice_data['elements']:
+                merged = {
+                    **parsed_lattice_data['elements']["apert"],
+                    **parsed_lattice_data['elements']["mark"]}    # Mark takes precedence
+                parsed_lattice_data['elements']["mark"] = merged
+            else:
+                parsed_lattice_data['elements']["mark"] = \
+                    parsed_lattice_data['elements']["apert"]
+
+            parsed_lattice_data['elements'].pop("apert")
 
     ############################################################################
     # Build Environment
@@ -113,8 +113,6 @@ def convert_sad_to_xsuite(
         parsed_lattice_data = parsed_lattice_data,
         environment         = env,
         config              = config)
-    
-    print(env.vars)
 
     ########################################
     # Add reference particle from globals
@@ -302,7 +300,8 @@ def convert_sad_to_xsuite(
 
     line, offset_marker_locations   = convert_offset_markers(
         line                = line,
-        parsed_lattice_data = parsed_lattice_data)
+        parsed_lattice_data = parsed_lattice_data,
+        verbose             = config._verbose)
 
     ############################################################################
     # Breakpoint for testing

--- a/sad2xs/output_writer/_015_offset_markers.py
+++ b/sad2xs/output_writer/_015_offset_markers.py
@@ -97,9 +97,15 @@ for marker, insert_at_s_values in MARKER_POSITIONS.items():
 try:
     line.insert(marker_insertions, s_tol = {config.MARKER_INSERTION_TOLERANCE:.2E})
 except AssertionError as err:
+"""
+        if config._verbose:
+            output_string += """\
     print("Couldn't insert all the markers. Usually this is because of negative drifts")
     print(err)
-
+"""
+        else:
+            output_string += """\
+    pass
 """
 
         ########################################

--- a/tests/test_013_verbose.py
+++ b/tests/test_013_verbose.py
@@ -1,0 +1,68 @@
+"""
+(Unofficial) SAD to XSuite Converter
+
+Tests for converter verbosity behavior.
+"""
+
+################################################################################
+# Required Packages
+################################################################################
+import textwrap
+
+import xtrack as xt
+
+import sad2xs as s2x
+
+################################################################################
+# Helpers
+################################################################################
+def write_aperture_lattice(tmp_path):
+    """
+    Write a small SAD lattice containing one aperture element.
+    """
+    lattice_path = tmp_path / "aperture_lattice.sad"
+    lattice_path.write_text(textwrap.dedent("""\
+        MOMENTUM    = 1.0 GEV;
+
+        DRIFT       TEST_D      = (L = 1.0);
+        APERT       TEST_APERT  = (AX = 0.01 AY = 0.02);
+
+        MARK        START       = ()
+                    END         = ();
+
+        LINE        RING        = (START TEST_D TEST_APERT END);
+        """))
+
+    return lattice_path
+
+################################################################################
+# Verbosity Behavior
+################################################################################
+def test_verbose_does_not_change_aperture_marker_conversion(tmp_path, capsys):
+    """
+    Aperture-to-marker conversion should not depend on `_verbose`.
+    """
+    lattice_path = write_aperture_lattice(tmp_path)
+
+    line_quiet = s2x.convert_sad_to_xsuite(
+        sad_lattice_path             = str(lattice_path),
+        output_directory             = str(tmp_path),
+        line_name                    = "RING",
+        install_apertures_as_markers = True,
+        _verbose                     = False,
+        _test_mode                   = True)
+
+    captured = capsys.readouterr()
+
+    line_verbose = s2x.convert_sad_to_xsuite(
+        sad_lattice_path             = str(lattice_path),
+        output_directory             = str(tmp_path),
+        line_name                    = "RING",
+        install_apertures_as_markers = True,
+        _verbose                     = True,
+        _test_mode                   = True)
+
+    assert captured.out == ""
+    assert line_quiet.element_names == line_verbose.element_names
+    assert isinstance(line_quiet["test_apert"], xt.Marker)
+    assert isinstance(line_verbose["test_apert"], xt.Marker)


### PR DESCRIPTION
Fixes aperture-to-marker conversion so it no longer depends on _verbose, removes unconditional core converter output, gates remaining converter status/warning printouts, and adds a targeted regression test for quiet conversion behavior.