### PR TITLE
Improve macOS SAD installer build environment

### DIFF
--- a/_install_sad_macos.py
+++ b/_install_sad_macos.py
@@ -3,7 +3,7 @@ SAD Installation Script
 =============================================
 Author(s):  John P T Salvesen
 Email:      john.salvesen@cern.ch
-Date:       30-07-2025
+Date:       02-01-2026
 """
 
 ################################################################################
@@ -14,6 +14,7 @@ import subprocess
 from pathlib import Path
 import shutil
 import sys
+from typing import Iterable, Optional
 
 ################################################################################
 # User Parameters
@@ -21,10 +22,10 @@ import sys
 SAD_GIT_REPO_URL    = "https://github.com/KatsOide/SAD.git"
 
 HEADER              = "MacOS SAD Installation Script"
-AUTHOR              = "JPT Salvesen"
+AUTHOR              = "J.P.T. Salvesen"
 CONTACT_EMAIL       = "john.salvesen@cern.ch"
-VERSION             = "0.1.0"
-DATE                = "30/07/2025"
+VERSION             = "0.2.0"
+DATE                = "10/06/2026"
 
 ################################################################################
 # Setup
@@ -35,12 +36,34 @@ SRC_DIR             = INSTALL_ROOT / "src"
 SAD_EXECUTABLE      = SRC_DIR / "bin" / "gs"
 LAUNCHER_SCRIPT     = INSTALL_ROOT / "sad"
 
-BREW_PACKAGES       = {
-    "git":          "git",
-    "make":         "make",
-    "gfortran":     "gcc",      # gfortran is part of gcc
-    "nroff":        "groff",    # for manpage generation
-    "X11/Xlib.h":   "xquartz"}  # for X11 headers
+################################################################################
+# Command Error class
+################################################################################
+class CommandError(RuntimeError):
+    """
+    Raised when a subprocess returns non-zero.
+    --------------------------------
+    cmd : list[str]
+        Command that was run
+    returncode : int
+        Return code from the command
+    log_path : Path, optional
+        Path to log file (if any)
+    --------------------------------
+    """
+    def __init__(
+            self,
+            cmd:        Iterable[str],
+            returncode: int,
+            log_path:   Optional[Path]  = None):
+        self.cmd        = list(cmd)
+        self.returncode = returncode
+        self.log_path   = log_path
+
+        msg = f"Command failed ({returncode}): {' '.join(self.cmd)}"
+        if log_path:
+            msg += f"\nLog: {log_path}"
+        super().__init__(msg)
 
 ################################################################################
 # Installation Functions
@@ -49,50 +72,315 @@ BREW_PACKAGES       = {
 ########################################
 # Run shell commands
 ########################################
-def run(cmd, cwd = None, check = True):
+def _print_log_tail(log_path: Path, n: int = 120) -> None:
+    """
+    Print the last n lines of a log file (best-effort)
+    --------------------------------
+    log_path : Path
+        Path to the log file
+    n : int, default=120
+        Number of lines to print from the end of the log
+    --------------------------------
+    """
+    try:
+        txt     = log_path.read_text(errors="replace")
+        lines   = txt.splitlines()
+        tail    = lines[-n:] if len(lines) > n else lines
+        print("\n" + "#" * 80)
+        print(f"Last {len(tail)} lines of log: {log_path}")
+        print("#" * 80)
+        for line in tail:
+            print(line)
+        print("#" * 80 + "\n")
+    except FileNotFoundError:
+        print(f"(log missing) {log_path}")
+    except Exception as e:
+        print(f"(could not read log) {log_path}: {e}")
+
+########################################
+# Run shell commands
+########################################
+def run(
+        cmd,
+        cwd             = None,
+        env             = None,
+        check           = True,
+        log_path        = None,
+        stdin_devnull   = False):
+    """
+    Run a shell command
+    --------------------------------
+    cmd : list[str]
+        Command and arguments to run
+    cwd : Path or str, optional
+        Working directory to run the command in
+    env : dict, optional
+        Environment variables to use
+    check : bool, default=True
+        If True, raise CommandError on non-zero return code
+    log_path : Path, optional
+        If given, log stdout/stderr to this file
+    stdin_devnull : bool, default=False
+        If True, set stdin to /dev/null
+    --------------------------------
+    Returns:
+    subprocess.CompletedProcess if log_path is None, else return code (int)
+    --------------------------------
+    """
     print(f"▶ Running: {' '.join(cmd)}")
-    result = subprocess.run(cmd, cwd = cwd)
-    if check and result.returncode != 0:
-        sys.exit(f"Command failed: {' '.join(cmd)}")
+    if cwd:
+        print(f"  cwd: {cwd}")
+
+    stdin = subprocess.DEVNULL if stdin_devnull else None
+
+    if log_path is None:
+        p = subprocess.run(             # pylint: disable=subprocess-run-check
+            cmd,
+            cwd     = str(cwd) if cwd else None,
+            env     = env,
+            stdin   = stdin)
+        if check and p.returncode != 0:
+            raise CommandError(cmd, p.returncode)
+
+        return p
+
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("a") as f:
+        f.write(f"\n\n$ {' '.join(cmd)}\n")
+        f.flush()
+
+        proc = subprocess.Popen(
+            cmd,
+            cwd     = str(cwd) if cwd else None,
+            env     = env,
+            text    = True,
+            stdout  = subprocess.PIPE,
+            stderr  = subprocess.STDOUT,
+            stdin   = stdin,
+            bufsize = 1)
+        assert proc.stdout is not None
+        for line in proc.stdout:
+            sys.stdout.write(line)
+            f.write(line)
+        rc = proc.wait()
+
+    if check and rc != 0:
+        _print_log_tail(log_path, n = 120)
+        raise CommandError(cmd, rc, log_path = log_path)
+    return rc
 
 ########################################
-# Install with Homebrew
+# Clean Conda Build Environment
 ########################################
-def brew_install(pkg):
+def make_clean_build_env() -> dict[str, str]:
+    """
+    Make a clean build environment for building SAD on MacOS
+    Remove conda-related environment variables
+    Force use of Xcode toolchain.
+    """
+    env = os.environ.copy()
+
+    # Remove conda contamination + common build poisoning vars
+    for k in [
+            "CPPFLAGS", "LDFLAGS", "LDFLAGS_LD",
+            "CPATH", "C_INCLUDE_PATH", "CPLUS_INCLUDE_PATH", "LIBRARY_PATH",
+            "DYLD_LIBRARY_PATH", "DYLD_FALLBACK_LIBRARY_PATH",
+            "CONDA_PREFIX", "CONDA_DEFAULT_ENV", "CONDA_SHLVL",
+            "CONDA_TOOLCHAIN_HOST", "CONDA_TOOLCHAIN_BUILD",
+            "_CONDA_PYTHON_SYSCONFIGDATA_NAME",
+            "CC", "CXX", "FC", "F77", "F90",
+            "AR", "AS", "LD", "NM", "RANLIB", "STRIP",
+            "CMAKE_ARGS", "CMAKE_PREFIX_PATH",
+            "CONDA_BUILD", "PREFIX", "BUILD_PREFIX",
+            "HOST", "BUILD", "TARGET"]:
+        env.pop(k, None)
+
+    brew_root = brew_prefix()
+
+    # Use a deterministic PATH: Homebrew first, then system
+    env["PATH"]     = f"{brew_root}/bin:{brew_root}/sbin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+    # Force Xcode/CLT toolchain
+    env["SDKROOT"]  = subprocess.check_output(
+        ["xcrun", "--show-sdk-path"], text = True).strip()
+    env["CC"]       = subprocess.check_output(
+        ["xcrun", "--find", "clang"], text = True).strip()
+    env["CXX"]      = subprocess.check_output(
+        ["xcrun", "--find", "clang++"], text = True).strip()
+    env["AR"]       = subprocess.check_output(
+        ["xcrun", "--find", "ar"], text = True).strip()
+    env["RANLIB"]   = subprocess.check_output(
+        ["xcrun", "--find", "ranlib"], text = True).strip()
+    env["NM"]       = subprocess.check_output(
+        ["xcrun", "--find", "nm"], text = True).strip()
+    env["STRIP"]    = subprocess.check_output(
+        ["xcrun", "--find", "strip"], text = True).strip()
+    env["LD"]       = subprocess.check_output(
+        ["xcrun", "--find", "ld"], text = True).strip()
+
+    # Force Homebrew gfortran (change if you use MacPorts)
+    gcc_prefix      = brew_prefix("gcc")
+    env["FC"]       = str(Path(gcc_prefix) / "bin" / "gfortran")
+
+    # Optional: prevent any ftp-like downloader + make downloads reliable
+    env["FETCH"]    = "curl -L --retry 3 --retry-delay 2 --connect-timeout 15 --max-time 300 -O"
+
+    for k in ("CC", "CXX", "FC", "AR", "RANLIB", "NM", "LD", "STRIP"):
+        p   = Path(env[k])
+        if not p.exists():
+            sys.exit(f"Tool not found: {k}={p}")
+
+    return env
+
+########################################
+# Ensure Xcode Command Line Tools
+########################################
+def ensure_xcode_clt():
+    """
+    Ensure that Xcode Command Line Tools are installed
+    --------------------------------
+    """
+    p   = subprocess.run(             # pylint: disable=subprocess-run-check
+        ["xcode-select", "-p"],
+        stdout  = subprocess.DEVNULL,
+        stderr  = subprocess.DEVNULL)
+    if p.returncode != 0:
+        sys.exit(
+            "Xcode Command Line Tools not configured. Run: xcode-select --install")
+
+########################################
+# Dependencies
+########################################
+def brew_install(
+        pkg:    str,
+        cask:   bool    = False):
+    """
+    Install a package using Homebrew
+    --------------------------------
+    pkg : str
+        Name of the Homebrew package to install
+    --------------------------------
+
+    """
     print(f"Installing with Homebrew: {pkg}")
-    run(["brew", "install", pkg])
+    cmd = ["brew", "install"]
+    if cask:
+        cmd.append("--cask")
+    cmd.append(pkg)
+    run(cmd)
 
-########################################
-# Check for required dependencies
-########################################
-def check_dependency(cmd, brew_pkg):
-    if shutil.which(cmd) is None:   
-        print(f"Missing: command {cmd}")
-        print(f"Will install: {brew_pkg}")
-        brew_install(brew_pkg)
+def brew_prefix(formula: str | None = None) -> Path:
+    """
+    Return the Homebrew prefix.
+    --------------------------------
+    formula : str, optional
+        If given, return the prefix for a formula.
+    --------------------------------
+    """
+    cmd = ["brew", "--prefix"]
+    if formula is not None:
+        cmd.append(formula)
+
+    p = subprocess.run(             # pylint: disable=subprocess-run-check
+        cmd,
+        text    = True,
+        stdout  = subprocess.PIPE,
+        stderr  = subprocess.DEVNULL)
+
+    if p.returncode != 0:
+        if formula is None:
+            sys.exit("Homebrew prefix could not be found.")
+        brew_install(formula)
+        return brew_prefix(formula)
+
+    return Path(p.stdout.strip())
+
+def ensure_brew_bin_exists(
+        exe:        str,
+        formula:    str) -> Path:
+    """
+    Ensure that a given binary exists from Homebrew
+    Install the package if not.
+    --------------------------------
+    exe : str
+        Executable name under the formula `bin` directory.
+    formula : str
+        Name of the Homebrew package to install if missing
+    --------------------------------
+    """
+    prefix  = brew_prefix(formula)
+    p       = Path(prefix) / "bin" / exe
+    if not p.exists():
+        brew_install(formula)
+        prefix  = brew_prefix(formula)
+        p       = Path(prefix) / "bin" / exe
+    if not p.exists():
+        sys.exit(f"Homebrew formula {formula} did not provide expected executable: {p}")
+    return p
+
+def ensure_command_exists(
+        cmd:        str,
+        formula:    str):
+    """
+    Ensure that a command is available on PATH, installing a formula if missing.
+    --------------------------------
+    cmd : str
+        Command to search for.
+    formula : str
+        Homebrew formula to install if the command is missing.
+    --------------------------------
+    """
+    if shutil.which(cmd) is not None:
+        return
+
+    print(f"Missing: command {cmd}")
+    print(f"Will install: {formula}")
+    brew_install(formula)
+
+    if shutil.which(cmd) is None:
+        sys.exit(f"Command still not found after installing {formula}: {cmd}")
 
 def check_x11_headers():
+    """
+    Check for X11 headers, install xquartz if missing
+    --------------------------------
+    """
     x11_header = Path("/opt/X11/include/X11/Xlib.h")
     if not x11_header.exists():
         print("Missing: X11 headers")
         print("Will install: xquartz")
-        brew_install("xquartz")
+        brew_install("xquartz", cask = True)
 
-########################################
-# Install required dependencies
-########################################
 def install_dependencies():
-    print("Checking for required dependencies")
-    for check_cmd, brew_pkg in BREW_PACKAGES.items():
-        if check_cmd == "X11/Xlib.h":
-            check_x11_headers()
-        else:
-            check_dependency(check_cmd, brew_pkg)
+    """
+    Install required dependencies using Homebrew
+    --------------------------------
+    """
+    print("Checking for required dependencies (brew-based)")
+    # Ensure brew itself exists
+    if shutil.which("brew") is None:
+        sys.exit("Homebrew (brew) not found. Install it from brew.sh then rerun.")
+
+    # These are used explicitly later
+    ensure_command_exists("git", "git")
+    ensure_command_exists("make", "make")
+    ensure_command_exists("nroff", "groff")
+    ensure_brew_bin_exists("gfortran", "gcc")
+
+    # X11 headers
+    check_x11_headers()
 
 ########################################
 # Write global launcher script
 ########################################
 def write_launcher():
+    """
+    Write a global SAD launcher script to ~/bin/sad/sad
+    --------------------------------
+    1) If called with a file argument, runs in batch mode from the user's cwd
+    2) If called without arguments, runs interactively from the SAD source dir
+    --------------------------------
+    """
     print(f"Writing launcher script: {LAUNCHER_SCRIPT}")
     LAUNCHER_SCRIPT.write_text(f"""#!/bin/bash
 SAD_DIR="{SRC_DIR}"
@@ -101,7 +389,8 @@ CALL_DIR="$(pwd)"
 
 # If called with a file: run from the user's working directory (batch mode)
 if [[ $# -gt 0 ]]; then
-    SAD_INPUT="$(realpath "$CALL_DIR/$1")"
+    SAD_INPUT="$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$CALL_DIR/$1")"
+
     shift
     cd "$CALL_DIR" || exit 1
     exec "$GS_EXEC" "$SAD_INPUT" "$@"
@@ -117,6 +406,10 @@ fi
 # Append launcher to shell rc
 ########################################
 def append_to_shell_rc():
+    """
+    Append SAD bin directory to user's shell rc file
+    --------------------------------
+    """
     shell   = os.environ.get("SHELL", "")
     rc_file = None
     if "zsh" in shell:
@@ -153,6 +446,18 @@ def append_to_shell_rc():
 # Main Installation Process
 ################################################################################
 def main():
+    """
+    Main SAD installation process
+    --------------------------------
+    1) Install dependencies
+    2) Clean previous installation
+    3) Create install directory
+    4) Clone SAD repository
+    5) Build SAD
+    6) Write global launcher
+    7) Append to shell rc file
+    --------------------------------
+    """
 
     ########################################
     # Header
@@ -170,6 +475,7 @@ def main():
     # Install Dependencies
     ########################################
     print("#" * 40 + "\n" + "Installing Required Dependencies" + "\n" + "#" * 40)
+    ensure_xcode_clt()
     install_dependencies()
 
     ########################################
@@ -189,37 +495,53 @@ def main():
     print(f"Install directory created at {INSTALL_ROOT}")
 
     ########################################
+    # Create Logging
+    ########################################
+    print("#" * 40 + "\n" + "Creating Logging" + "\n" + "#" * 40)
+    LOG_DIR = INSTALL_ROOT / "logs"
+    LOG_DIR.mkdir(parents = True, exist_ok = True)
+
+    build_log = LOG_DIR / "build.log"
+    # Start fresh each run (optional)
+    build_log.write_text("")
+    print(f"Build log: {build_log}")
+
+    ########################################
     # Clone SAD Repository
     ########################################
     print("#" * 40 + "\n" + "Cloning SAD Repository" + "\n" + "#" * 40)
-    run(["git", "clone", SAD_GIT_REPO_URL, str(SRC_DIR)])
-
-    ########################################
-    # Patching SAD Configuration
-    ########################################
-    print("#" * 40 + "\n" + "Patching SAD config for local installation" + "\n" + "#" * 40)
-    print("For local installation, using only the first 70 lines of sad.conf")
-    # Original Makefile.unx and sad.conf files designed for legacy Unix
-    # KEK's installation instructions say:
-    #   "Use only the first 70 lines of sad.conf for building SAD locally."
-
-    sad_conf        = SRC_DIR / "sad.conf"
-    patched_conf    = SRC_DIR / "sad.conf.new"
-    with sad_conf.open() as f_in, patched_conf.open("w") as f_out:
-        for i, line in enumerate(f_in):
-            if i < 70:
-                f_out.write(line)
-            else:
-                break
-    sad_conf.unlink()
-    patched_conf.rename(sad_conf)
+    run(
+        ["git", "clone", SAD_GIT_REPO_URL, str(SRC_DIR)],
+        log_path        = build_log,
+        stdin_devnull   = True)
 
     ########################################
     # Build SAD
     ########################################
     print("#" * 40 + "\n" + "Building SAD" + "\n" + "#" * 40)
-    run(["make", "depend"], cwd = SRC_DIR)
-    run(["make", "-s", "exe"], cwd = SRC_DIR)
+
+    build_env = make_clean_build_env()
+
+    run(
+        ["make", "clean"],
+        cwd             = SRC_DIR,
+        env             = build_env,
+        log_path        = build_log,
+        stdin_devnull   = True,
+        check           = False)
+    run(
+        ["make", "depend"],
+        cwd             = SRC_DIR,
+        env             = build_env,
+        log_path        = build_log,
+        stdin_devnull   = True)
+    run(
+        ["make", "exe"],
+        cwd             = SRC_DIR,
+        env             = build_env,
+        log_path        = build_log,
+        stdin_devnull   = True)
+
     print("SAD build complete")
 
     # Test SAD Installation
@@ -243,7 +565,7 @@ def main():
     ########################################
     print("#" * 40 + "\n" + "SAD Installation Summary" + "\n" + "#" * 40)
     print("SAD installed successfully!")
-    print(f"Run:        sad sad_file.sad")
+    print("Run:        sad sad_file.sad")
     print(f"Source:     {SRC_DIR}")
     print(f"Launcher:   {LAUNCHER_SCRIPT}")
 

--- a/tests/test_014_install_sad_macos.py
+++ b/tests/test_014_install_sad_macos.py
@@ -1,0 +1,51 @@
+"""
+(Unofficial) SAD to XSuite Converter
+
+Tests for the macOS SAD installer helpers.
+"""
+
+################################################################################
+# Required Packages
+################################################################################
+import _install_sad_macos as installer
+
+################################################################################
+# Homebrew Helpers
+################################################################################
+def test_brew_install_uses_cask_flag(monkeypatch):
+    """
+    Cask dependencies should be installed with `brew install --cask`.
+    """
+    commands = []
+
+    def fake_run(cmd):
+        commands.append(cmd)
+
+    monkeypatch.setattr(installer, "run", fake_run)
+
+    installer.brew_install("xquartz", cask = True)
+
+    assert commands == [["brew", "install", "--cask", "xquartz"]]
+
+def test_ensure_brew_bin_exists_uses_executable_name(tmp_path, monkeypatch):
+    """
+    Homebrew binary checks should not duplicate the `bin` path component.
+    """
+    prefix  = tmp_path / "gcc"
+    bin_dir = prefix / "bin"
+    exe     = bin_dir / "gfortran"
+
+    bin_dir.mkdir(parents = True)
+    exe.touch()
+
+    def fake_brew_prefix(formula):
+        assert formula == "gcc"
+        return prefix
+
+    def fail_brew_install(formula):
+        raise AssertionError(f"Unexpected install attempt for {formula}")
+
+    monkeypatch.setattr(installer, "brew_prefix", fake_brew_prefix)
+    monkeypatch.setattr(installer, "brew_install", fail_brew_install)
+
+    assert installer.ensure_brew_bin_exists("gfortran", "gcc") == exe


### PR DESCRIPTION
Improves the macOS SAD installer by using a clean build environment, logging build output, improving Homebrew dependency checks, handling XQuartz as a cask dependency, and adding targeted tests for installer helper behavior. The installer has been manually tested locally against SAD and an example workflow.