### PR TITLE
Support spaced SAD element expressions

### DIFF
--- a/sad2xs/converter/_001_parser.py
+++ b/sad2xs/converter/_001_parser.py
@@ -9,11 +9,54 @@ Date:       09-12-2025
 ################################################################################
 # Required Packages
 ################################################################################
+import re
+
 import xtrack as xt
 import numpy as np
 
 from ..types import ConfigLike
 from ..helpers import print_section_heading
+
+################################################################################
+# Element Parameter Parsing
+################################################################################
+ELEMENT_PARAMETER_PATTERN = re.compile(r"(?<!\S)([a-z][a-z0-9_]*)\s*=")
+
+def split_element_parameters(ele_vars: str) -> list[tuple[str, str]]:
+    """
+    Split an element parameter string into complete name/value pairs.
+
+    SAD element values can be arithmetic expressions with spaces. Splitting the
+    whole parameter string on whitespace would break expressions such as
+    `l=l0 + dl`. This function instead splits at parameter assignments.
+    """
+    parameters = []
+    matches = list(ELEMENT_PARAMETER_PATTERN.finditer(ele_vars))
+
+    if len(matches) == 0:
+        if ele_vars.strip():
+            raise ValueError(
+                f"Error parsing element variables: {ele_vars}. "
+                "Expected one or more 'name = value' assignments.")
+        return parameters
+
+    for index, match in enumerate(matches):
+        var_name    = match.group(1)
+        value_start = match.end()
+        value_end   = (
+            matches[index + 1].start()
+            if index + 1 < len(matches)
+            else len(ele_vars))
+
+        var_value = ele_vars[value_start:value_end].strip()
+        if len(var_value) == 0:
+            raise ValueError(
+                f"Error parsing element variable: {var_name}. "
+                "Expected a value after '='.")
+
+        parameters.append((var_name, var_value))
+
+    return parameters
 
 ################################################################################
 # Electron Volt Conversion
@@ -406,29 +449,14 @@ def parse_sad_file(
                 ########################################
                 # Process data in each element
                 ########################################
-                tokens  = ele_vars.split(" ")
-                for token in tokens:
-
-                    if len(token) == 0:
-                        continue
+                for var_name, var_value in split_element_parameters(ele_vars):
 
                     ########################################
                     # Angle handling
                     ########################################
-                    if "deg" in token:
-                        token_name, token_value = token.split("=")
-
-                        token_value = token_value.replace("deg", "")
-                        token_value = float(token_value)
-                        token_value = np.deg2rad(token_value)
-                        token = token_name + "=" + str(token_value)
-
-                    try:
-                        var_name, var_value = token.split("=")
-                    except ValueError:
-                        raise ValueError(
-                            f"Error parsing token: {token}. "
-                            "Expected format 'name = value'.")
+                    if "deg" in var_value:
+                        var_value = var_value.replace("deg", "")
+                        var_value = np.deg2rad(float(var_value))
 
                     try:
                         var_value = float(var_value)

--- a/tests/parser/test_003_element_expressions.py
+++ b/tests/parser/test_003_element_expressions.py
@@ -1,0 +1,124 @@
+"""
+(Unofficial) SAD to XSuite Converter
+
+Tests for SAD parser element expression handling.
+"""
+
+################################################################################
+# Required Packages
+################################################################################
+import textwrap
+
+import numpy as np
+import pytest
+import xtrack as xt
+
+from sad2xs.config import Config
+from sad2xs.converter._001_parser import parse_sad_file
+from sad2xs.converter._003_expression_converter import convert_expressions
+from sad2xs.converter._004_element_converter import convert_drifts
+
+################################################################################
+# Helpers
+################################################################################
+def write_lattice(tmp_path, content, filename = "test_lattice.sad"):
+    """
+    Write a temporary SAD lattice file for parser tests.
+    """
+    lattice_path = tmp_path / filename
+    lattice_path.write_text(textwrap.dedent(content))
+    return lattice_path
+
+################################################################################
+# Element Expressions
+################################################################################
+def test_element_parameters_accept_spaced_arithmetic_expressions(tmp_path):
+    """
+    Element values with spaced arithmetic should remain complete expressions.
+    """
+    lattice_path = write_lattice(
+        tmp_path,
+        """\
+        MOMENTUM = 1.0 GEV;
+        L0 = 1.0;
+        DL = 0.25;
+        KBASE = 0.8;
+        DK = 0.1;
+        THETA = 0.02;
+
+        DRIFT D_PLUS = (L = L0 + DL);
+        DRIFT D_MINUS = (L = L0 - DL);
+        QUAD Q_EXPR = (L = L0 + DL K1 = KBASE - DK ROTATE = 45 DEG);
+        BEND B_EXPR = (L = 2 * L0 ANGLE = THETA / 2);
+        """,
+        filename = "element_spaced_expressions.sad")
+
+    parsed = parse_sad_file(str(lattice_path), Config(_verbose = False))
+
+    assert parsed["elements"]["drift"]["d_plus"]["l"] == "l0 + dl"
+    assert parsed["elements"]["drift"]["d_minus"]["l"] == "l0 - dl"
+    assert parsed["elements"]["quad"]["q_expr"]["l"] == "l0 + dl"
+    assert parsed["elements"]["quad"]["q_expr"]["k1"] == "kbase - dk"
+    assert parsed["elements"]["quad"]["q_expr"]["rotate"] == pytest.approx(
+        np.pi / 4)
+    assert parsed["elements"]["bend"]["b_expr"]["l"] == "2 * l0"
+    assert parsed["elements"]["bend"]["b_expr"]["angle"] == "theta / 2"
+
+def test_element_parameters_keep_compact_expressions_and_numeric_values(tmp_path):
+    """
+    Existing compact expressions and plain numeric parameters should be unchanged.
+    """
+    lattice_path = write_lattice(
+        tmp_path,
+        """\
+        MOMENTUM = 1.0 GEV;
+        L0 = 1.0;
+        DL = 0.25;
+        KBASE = 0.8;
+        DK = 0.1;
+
+        DRIFT D_FLOAT = (L = 1.25);
+        DRIFT D_COMPACT = (L = L0+DL);
+        QUAD Q_FLOAT = (L = 2.0 K1 = 0.4);
+        QUAD Q_COMPACT = (L = L0 K1 = KBASE-DK);
+        """,
+        filename = "element_compact_expressions.sad")
+
+    parsed = parse_sad_file(str(lattice_path), Config(_verbose = False))
+
+    assert parsed["elements"]["drift"]["d_float"]["l"] == pytest.approx(1.25)
+    assert parsed["elements"]["drift"]["d_compact"]["l"] == "l0+dl"
+    assert parsed["elements"]["quad"]["q_float"]["l"] == pytest.approx(2.0)
+    assert parsed["elements"]["quad"]["q_float"]["k1"] == pytest.approx(0.4)
+    assert parsed["elements"]["quad"]["q_compact"]["l"] == "l0"
+    assert parsed["elements"]["quad"]["q_compact"]["k1"] == "kbase-dk"
+
+def test_spaced_length_expression_can_be_evaluated_in_xsuite_environment(
+        tmp_path):
+    """
+    Parsed spaced expressions should remain usable by Xsuite element creation.
+    """
+    lattice_path = write_lattice(
+        tmp_path,
+        """\
+        MOMENTUM = 1.0 GEV;
+        L0 = 1.0;
+        DL = 0.25;
+
+        DRIFT D_EVAL = (L = L0 + DL);
+        """,
+        filename = "element_expression_evaluation.sad")
+
+    config = Config(_verbose = False)
+    parsed = parse_sad_file(str(lattice_path), config)
+
+    environment = xt.Environment()
+    convert_expressions(
+        parsed_lattice_data = parsed,
+        environment         = environment,
+        config              = config)
+    convert_drifts(
+        parsed_elements = parsed["elements"],
+        environment     = environment)
+
+    assert environment["d_eval"].length == pytest.approx(1.25)


### PR DESCRIPTION
Resolves #31 for release/0.3.0. Preserves complete arithmetic expressions in SAD element parameters instead of splitting them on whitespace. Adds parser regression tests for spaced arithmetic, compact expressions, numeric values, and Xsuite environment evaluation.