### PR TITLE
Fix write_lattice for standalone xt.Line input

### DIFF
--- a/sad2xs/converter/_010_write_lattice.py
+++ b/sad2xs/converter/_010_write_lattice.py
@@ -64,17 +64,17 @@ def write_lattice(
     try:
         line["p0c"]
     except KeyError:
-        line["p0c"]     = line.particle_ref.p0c                 # type: ignore
+        line["p0c"]     = line.particle_ref.p0c.item()          # type: ignore
 
     try:
         line["mass0"]
     except KeyError:
-        line["mass0"]   = line.particle_ref.mass0               # type: ignore
+        line["mass0"]   = line.particle_ref.mass0.item()        # type: ignore
 
     try:
         line["q0"]
     except KeyError:
-        line["q0"]      = line.particle_ref.q0                  # type: ignore
+        line["q0"]      = line.particle_ref.q0.item()           # type: ignore
 
     try:
         line["fshift"]


### PR DESCRIPTION
## Summary

- `particle_ref` attributes (`p0c`, `mass0`, `q0`) are numpy arrays of shape `(1,)`, not scalars
- The fallback block in `write_lattice` (lines 64–82) assigned them directly to Xsuite environment variables, raising `ValueError: Only scalars or references are allowed`
- Fix: use `.item()` to extract a Python-native scalar from the single-element array

## Test plan

- [ ] Run `tests/writer/` in verbose mode after merging and rebasing the test branch — all writer element tests should unblock (or surface the next distinct failure if `get_table(attr=True)` also needs attention for standalone lines)
- [ ] Existing SAD conversion tests unaffected: the fallback block only runs when `p0c` is not already in the line's environment, which is never the case for SAD-converted lines

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)