### PR TITLE
Fix track_sad TBT no-progress branch: single-brace Table iterator (#64)

### DIFF
--- a/sad2xs/sad_helpers/track.py
+++ b/sad2xs/sad_helpers/track.py
@@ -253,7 +253,7 @@ r1 = Table[
         beam = TrackParticles[beam, 1, turn, turn];
         beam[[2]]
     ),
-    {{turn, 1, turns}}
+    {turn, 1, turns}
     ];
 WriteString[6,"TRACKING COMPLETE \\n"];
 


### PR DESCRIPTION
## Summary

- Fixes `track_sad` with `turn_by_turn_monitor=True, with_progress=False` producing `ValueError: string or file could not be read to its end due to unmatched data`
- One character change: `{{turn, 1, turns}}` → `{turn, 1, turns}` in the plain-string TBT branch

## Root cause

The `turn_by_turn_monitor and not with_progress` branch appends a plain `"""..."""` string. In plain strings `{{}}` are literal double braces; in f-strings they escape to `{}`. So the SAD file received `{{turn, 1, turns}}` as the Table iterator — a nested list rather than the iterator spec `{turn, 1, turns}`. SAD's Table left `r1` unevaluated, `Put[r, ...]` wrote the symbol literal `r` to the dat file, and `np.fromstring` failed on non-numeric content.

The other two Table sites (lines 222, 284) are in f-strings and were unaffected.

## Note on issue description

Issue #64 listed lines 222 and 284 as also affected — that was incorrect. Both are in f-strings where `{{}}` correctly produces `{}`. Only line 256 (the plain-string branch) required a fix.

## Test plan

- [ ] `pytest tests/sad_helpers/test_track_sad.py -v` — the two previously failing TBT tests (`test_track_sad_turn_by_turn_shape_matches_particles_and_turns`, `test_track_sad_on_axis_particle_stays_on_axis_in_drift`) should now pass after rebasing the test branch on this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)