### PR TITLE
Use file-based SAD output for chromaticity helpers

### DIFF
--- a/docs/sad-helpers.md
+++ b/docs/sad-helpers.md
@@ -97,7 +97,9 @@ Default wall times are currently short for optics-style helpers and longer for t
 
 ## Temporary files
 
-The helpers currently write fixed temporary filenames in the current working directory, for example:
+`chromaticity_sad` and `transfer_matrix_sad` write UUID-named temporary files directly in the current working directory (e.g. `_sad_chrom_<uid>.sad`, `_sad_chrom_<uid>.dat`) and remove them in a `finally` block, so concurrent calls and interrupted runs are both safe for these two helpers.
+
+The remaining helpers write fixed temporary filenames in the current working directory, for example:
 
 - `temp_sad_twiss.sad`
 - `temp_sad_twiss.tfs`
@@ -106,13 +108,11 @@ The helpers currently write fixed temporary filenames in the current working dir
 - `temp_sad_track.sad`
 - `temp_sad_track.dat`
 - `temp_sad_emit.sad`
-- `temp_sad_tmatrix.sad`
-- `temp_sad_chromaticity.sad`
 - `temp_sad_rebuild_lattice.sad`
 
-This means helper calls should not be run concurrently from the same working directory. It also means failed or interrupted processes may leave temporary files behind.
+For these helpers, concurrent calls from the same working directory are not safe, and failed or interrupted processes may leave temporary files behind.
 
-Next release target: move these helpers to isolated temporary directories, preferably using Python temporary directory APIs or pytest `tmp_path` in tests.
+Note: SAD resolves paths relative to the directory of the input script file, so temporary script files must be written to the same directory as the lattice file (i.e. the Python process cwd).
 
 ## Current safeguards
 
@@ -130,8 +130,8 @@ Known limitations:
 
 - helper imports and execution depend on optional runtime dependencies;
 - top-level package import still re-exports the helper package;
-- temporary files use fixed names in the current working directory;
-- helper calls are not safe to run concurrently from the same directory;
+- most helpers use fixed temporary filenames in cwd; concurrent calls from the same directory are not safe for these;
+- `chromaticity_sad` and `transfer_matrix_sad` use UUID-named files with guaranteed cleanup;
 - `additional_commands` is raw SAD text and is not sandboxed or validated;
 - subprocess output parsing is tailored to the current generated SAD commands;
 - cleanup is not guaranteed for every interrupted or unexpected failure path;

--- a/sad2xs/sad_helpers/chromaticity.py
+++ b/sad2xs/sad_helpers/chromaticity.py
@@ -7,7 +7,7 @@
 ################################################################################
 import os
 import subprocess
-import ast
+import uuid
 import numpy as np
 
 ################################################################################
@@ -37,7 +37,7 @@ CalculateOffMomentumTune[x_]:={
     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     ! Get the fractional tunes
     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-    FractionalPart[Twiss["NX","$$$"]/(2*Pi)], 
+    FractionalPart[Twiss["NX","$$$"]/(2*Pi)],
     FractionalPart[Twiss["NY","$$$"]/(2*Pi)]
 };
 """
@@ -59,10 +59,19 @@ def chromaticity_sad(
     Generate a SAD command to compute the chromaticity parameters of a lattice.
     """
 
-    ########################################
-    # Generate the twiss command
-    ########################################
     print("Creating SAD Command")
+
+    ########################################
+    # SAD changes cwd to the directory of
+    # the input script, so the script must
+    # live in cwd (same dir as the lattice).
+    # Use uuid names to avoid collisions;
+    # try/finally ensures cleanup.
+    ########################################
+    uid      = uuid.uuid4().hex[:12]
+    cmd_file = f"_sad_chrom_{uid}.sad"
+    out_file = f"_sad_chrom_{uid}.dat"
+
     sad_command = f"""OFF ECHO;
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -95,13 +104,16 @@ SAVE ALL;
 {generate_off_momentum_tune_function()}
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-! Scan chromaticity
+! Scan chromaticity and write directly to file (dp qx qy per row)
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-d = Table[
-    tunes   = CalculateOffMomentumTune[x];
-    {{x, tunes[1], tunes[2]}},
-    {{x, -{dp_extent}, {dp_extent}, {dp_step} }}];
-Print[d];
+fn = OpenWrite["{out_file}"];
+$FORM="12.10";
+Table[
+    tunes = CalculateOffMomentumTune[x];
+    WriteString[fn, x, " ", tunes[1], " ", tunes[2], "\\n"],
+    {{x, -{dp_extent}, {dp_extent}, {dp_step} }}
+];
+Close[fn];
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! Close process
@@ -109,58 +121,32 @@ Print[d];
 abort;
 """
 
-    ########################################
-    # Write the SAD command
-    ########################################
-    with open("temp_sad_chromaticity.sad", "w", encoding = "utf-8") as f:
-        f.write(sad_command)
-
-    ########################################
-    # Run the process
-    ########################################
     try:
-        process = subprocess.run(
-            [sad_path, "temp_sad_chromaticity.sad"],
-            capture_output  = True,
-            text            = True,
-            timeout         = wall_time,
-            check           = True)
-    except subprocess.TimeoutExpired:
-        print(f"SAD Twiss timed out at {wall_time}s")
-        if os.path.exists("temp_sad_chromaticity.sad"):
-            os.remove("temp_sad_chromaticity.sad")
-        raise
-    except subprocess.CalledProcessError as e:
-        print(f"SAD exited with non-zero status {e.returncode}")
-        print("stdout:", e.stdout)
-        print("stderr:", e.stderr)
-        if os.path.exists("temp_sad_chromaticity.sad"):
-            os.remove("temp_sad_chromaticity.sad")
-        raise
+        with open(cmd_file, "w", encoding = "utf-8") as f:
+            f.write(sad_command)
+
+        try:
+            subprocess.run(
+                [sad_path, cmd_file],
+                capture_output = True,
+                text           = True,
+                timeout        = wall_time,
+                check          = True)
+        except subprocess.TimeoutExpired:
+            print(f"SAD Twiss timed out at {wall_time}s")
+            raise
+        except subprocess.CalledProcessError as e:
+            print(f"SAD exited with non-zero status {e.returncode}")
+            print("stdout:", e.stdout)
+            print("stderr:", e.stderr)
+            raise
+
+        chrom_scan = np.loadtxt(out_file, ndmin = 2)
+
     finally:
-        if os.path.exists("temp_sad_chromaticity.sad"):
-            os.remove("temp_sad_chromaticity.sad")
-
-    ########################################
-    # Read the data
-    ########################################
-    raw = process.stdout
-
-    ########################################
-    # Process the output
-    ########################################
-    start   = raw.find("{{")
-    end     = raw.rfind("}}")
-    if start == -1 or end == -1:
-        raise ValueError("Table not found in subprocess output")
-    matrix_str = raw[start:end + 2]
-
-    ########################################
-    # Convert to numpy array
-    ########################################
-    cleaned     = matrix_str.replace("}", "]").replace("{", "[")
-    matrix_list = ast.literal_eval(cleaned)
-    chrom_scan  = np.array(matrix_list, dtype = float)
+        for path in [cmd_file, out_file]:
+            if os.path.exists(path):
+                os.remove(path)
 
     ########################################
     # Data evaluation

--- a/sad2xs/sad_helpers/transfer_matrix.py
+++ b/sad2xs/sad_helpers/transfer_matrix.py
@@ -7,6 +7,7 @@
 ################################################################################
 import os
 import subprocess
+import uuid
 import ast
 import numpy as np
 
@@ -35,7 +36,7 @@ def transfer_matrix_sad(
     end_element : str | None, optional
         Name of the ending element for the transfer matrix calculation.
         If None, the end of the beamline is used.
-    
+
     Returns
     -------
     np.ndarray
@@ -50,10 +51,19 @@ def transfer_matrix_sad(
     if start_element is None and end_element is not None:
         raise ValueError("If end_element is provided, start_element must also be provided")
 
-    ########################################
-    # Generate the Transfer Matrix command
-    ########################################
     print("Creating SAD Command")
+
+    ########################################
+    # SAD changes cwd to the directory of
+    # the input script, so the script must
+    # live in cwd (same dir as the lattice).
+    # Use uuid names to avoid collisions;
+    # try/finally ensures cleanup.
+    ########################################
+    uid      = uuid.uuid4().hex[:12]
+    cmd_file = f"_sad_tmatrix_{uid}.sad"
+    out_file = f"_sad_tmatrix_{uid}.dat"
+
     if start_element is not None and end_element is not None:
         sad_command = f"""OFF ECHO;
 
@@ -76,11 +86,11 @@ CALC;
 TM = TransferMatrix["{start_element}", "{end_element}"];
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-! Print to output
+! Write matrix to file in SAD native format
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-WriteString[6, "! START TM"];
-WriteString[6, TM];
-WriteString[6, "! END TM"];
+fn = OpenWrite["{out_file}"];
+WriteString[fn, TM];
+Close[fn];
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! Close process
@@ -109,11 +119,11 @@ CALC;
 TM = TransferMatrix[1, -1];
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-! Print to output
+! Write matrix to file in SAD native format
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-WriteString[6, "! START TM"];
-WriteString[6, TM];
-WriteString[6, "! END TM"];
+fn = OpenWrite["{out_file}"];
+WriteString[fn, TM];
+Close[fn];
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! Close process
@@ -121,58 +131,41 @@ WriteString[6, "! END TM"];
 abort;
 """
 
-    ########################################
-    # Write the SAD command
-    ########################################
-    with open("temp_sad_tmatrix.sad", "w", encoding = "utf-8") as f:
-        f.write(sad_command)
-    del sad_command
-
-    ########################################
-    # Run the process
-    ########################################
     try:
-        process = subprocess.run(
-            [sad_path, "temp_sad_tmatrix.sad"],
-            capture_output  = True,
-            text            = True,
-            timeout         = wall_time,
-            check           = True)
-    except subprocess.TimeoutExpired:
-        print(f"SAD Twiss timed out at {wall_time}s")
-        if os.path.exists("temp_sad_tmatrix.sad"):
-            os.remove("temp_sad_tmatrix.sad")
-        raise
-    except subprocess.CalledProcessError as e:
-        print(f"SAD exited with non-zero status {e.returncode}")
-        print("stdout:", e.stdout)
-        print("stderr:", e.stderr)
-        if os.path.exists("temp_sad_tmatrix.sad"):
-            os.remove("temp_sad_tmatrix.sad")
-        raise
+        with open(cmd_file, "w", encoding = "utf-8") as f:
+            f.write(sad_command)
+
+        try:
+            subprocess.run(
+                [sad_path, cmd_file],
+                capture_output = True,
+                text           = True,
+                timeout        = wall_time,
+                check          = True)
+        except subprocess.TimeoutExpired:
+            print(f"SAD Twiss timed out at {wall_time}s")
+            raise
+        except subprocess.CalledProcessError as e:
+            print(f"SAD exited with non-zero status {e.returncode}")
+            print("stdout:", e.stdout)
+            print("stderr:", e.stderr)
+            raise
+
+        with open(out_file, "r", encoding = "utf-8") as f:
+            raw = f.read()
+
+        start = raw.find("{{")
+        end   = raw.rfind("}}")
+        if start == -1 or end == -1:
+            raise ValueError("Matrix not found in output file")
+        matrix_str  = raw[start:end + 2]
+        cleaned     = matrix_str.replace("}", "]").replace("{", "[")
+        matrix_list = ast.literal_eval(cleaned)
+        rmatrix     = np.array(matrix_list, dtype = float)
+
     finally:
-        if os.path.exists("temp_sad_tmatrix.sad"):
-            os.remove("temp_sad_tmatrix.sad")
-
-    ########################################
-    # Read the output
-    ########################################
-    raw = process.stdout
-
-    ########################################
-    # Process the output
-    ########################################
-    start   = raw.find("{{")
-    end     = raw.rfind("}}")
-    if start == -1 or end == -1:
-        raise ValueError("Matrix not found in subprocess output")
-    matrix_str = raw[start:end + 2]
-
-    ########################################
-    # Convert to numpy array
-    ########################################
-    cleaned     = matrix_str.replace("}", "]").replace("{", "[")
-    matrix_list = ast.literal_eval(cleaned)
-    rmatrix     = np.array(matrix_list, dtype = float)
+        for path in [cmd_file, out_file]:
+            if os.path.exists(path):
+                os.remove(path)
 
     return rmatrix


### PR DESCRIPTION
## Summary

- replace chromaticity stdout parsing with file-based SAD output in temporary directories
- apply the same file-based output approach to transfer-matrix extraction
- update SAD helper documentation for the new behavior

## Validation

- awaiting PR test checks

Closes #69