### PR TITLE
Isolate SAD helper subprocesses in temporary directories

### DIFF
--- a/docs/sad-helpers.md
+++ b/docs/sad-helpers.md
@@ -97,20 +97,9 @@ Default wall times are currently short for optics-style helpers and longer for t
 
 ## Temporary files
 
-`chromaticity_sad` and `transfer_matrix_sad` write UUID-named temporary files directly in the current working directory (e.g. `_sad_chrom_<uid>.sad`, `_sad_chrom_<uid>.dat`) and remove them in a `finally` block, so concurrent calls and interrupted runs are both safe for these two helpers.
+All helpers write UUID-named temporary files directly in the current working directory (e.g. `_sad_chrom_<uid>.sad`) and remove them in a `finally` block. Concurrent calls from the same working directory are safe, and files are cleaned up on both normal and error exits.
 
-The remaining helpers write fixed temporary filenames in the current working directory, for example:
-
-- `temp_sad_twiss.sad`
-- `temp_sad_twiss.tfs`
-- `temp_sad_survey.sad`
-- `temp_sad_survey.tfs`
-- `temp_sad_track.sad`
-- `temp_sad_track.dat`
-- `temp_sad_emit.sad`
-- `temp_sad_rebuild_lattice.sad`
-
-For these helpers, concurrent calls from the same working directory are not safe, and failed or interrupted processes may leave temporary files behind.
+`rebuild_sad_lattice` also writes a user-specified output lattice file; that file is intentionally persistent and is not cleaned up automatically.
 
 Note: SAD resolves paths relative to the directory of the input script file, so temporary script files must be written to the same directory as the lattice file (i.e. the Python process cwd).
 
@@ -120,7 +109,7 @@ The helper layer currently provides these safeguards:
 
 - `wall_time` limits for external SAD calls;
 - `check=True` for most subprocess calls, so non-zero SAD exits are treated as failures;
-- cleanup of known temporary command files on many normal, timeout, and handled error paths;
+- UUID-named temporary files with guaranteed cleanup via `finally` on all exit paths;
 - array shape and size assertions in `track_sad`;
 - explicit validation that `transfer_matrix_sad` receives either both `start_element` and `end_element`, or neither.
 
@@ -130,11 +119,8 @@ Known limitations:
 
 - helper imports and execution depend on optional runtime dependencies;
 - top-level package import still re-exports the helper package;
-- most helpers use fixed temporary filenames in cwd; concurrent calls from the same directory are not safe for these;
-- `chromaticity_sad` and `transfer_matrix_sad` use UUID-named files with guaranteed cleanup;
 - `additional_commands` is raw SAD text and is not sandboxed or validated;
 - subprocess output parsing is tailored to the current generated SAD commands;
-- cleanup is not guaranteed for every interrupted or unexpected failure path;
 - some error messages still use generic wording from earlier Twiss-only implementations.
 
 Next release target: address these limitations incrementally without making the core converter depend on an external SAD installation.

--- a/sad2xs/sad_helpers/emit.py
+++ b/sad2xs/sad_helpers/emit.py
@@ -7,6 +7,7 @@
 ################################################################################
 import os
 import subprocess
+import uuid
 
 ################################################################################
 # EMIT
@@ -32,6 +33,9 @@ def emit_sad(
     ########################################
     # Generate the twiss command
     ########################################
+    uid      = uuid.uuid4().hex[:12]
+    cmd_file = f"_sad_emit_{uid}.sad"
+
     print("Creating SAD Command")
     sad_command = f"""OFF ECHO;
 
@@ -73,38 +77,30 @@ WriteString[6, "! END EMIT"];
 abort;
 """
 
-    ########################################
-    # Write the SAD command
-    ########################################
-    with open("temp_sad_emit.sad", "w", encoding = "utf-8") as f:
-        f.write(sad_command)
-    del sad_command
-
-    ########################################
-    # Run the process
-    ########################################
     try:
-        process = subprocess.run(
-            [sad_path, "temp_sad_emit.sad"],
-            capture_output  = True,
-            text            = True,
-            timeout         = wall_time,
-            check           = True)
-    except subprocess.TimeoutExpired:
-        print(f"SAD Twiss timed out at {wall_time}s")
-        if os.path.exists("temp_sad_emit.sad"):
-            os.remove("temp_sad_emit.sad")
-        raise
-    except subprocess.CalledProcessError as e:
-        print(f"SAD exited with non-zero status {e.returncode}")
-        print("stdout:", e.stdout)
-        print("stderr:", e.stderr)
-        if os.path.exists("temp_sad_emit.sad"):
-            os.remove("temp_sad_emit.sad")
-        raise
+        with open(cmd_file, "w", encoding = "utf-8") as f:
+            f.write(sad_command)
+        del sad_command
+
+        try:
+            process = subprocess.run(
+                [sad_path, cmd_file],
+                capture_output  = True,
+                text            = True,
+                timeout         = wall_time,
+                check           = True)
+        except subprocess.TimeoutExpired:
+            print(f"SAD Twiss timed out at {wall_time}s")
+            raise
+        except subprocess.CalledProcessError as e:
+            print(f"SAD exited with non-zero status {e.returncode}")
+            print("stdout:", e.stdout)
+            print("stderr:", e.stderr)
+            raise
+
     finally:
-        if os.path.exists("temp_sad_emit.sad"):
-            os.remove("temp_sad_emit.sad")
+        if os.path.exists(cmd_file):
+            os.remove(cmd_file)
 
     ########################################
     # Read the terminal output

--- a/sad2xs/sad_helpers/rebuild_lattice.py
+++ b/sad2xs/sad_helpers/rebuild_lattice.py
@@ -7,6 +7,7 @@
 ################################################################################
 import os
 import subprocess
+import uuid
 
 ################################################################################
 # Rebuild SAD lattice
@@ -43,6 +44,9 @@ def rebuild_sad_lattice(
     ########################################
     # Generate the twiss command
     ########################################
+    uid      = uuid.uuid4().hex[:12]
+    cmd_file = f"_sad_rebuild_{uid}.sad"
+
     print("Creating SAD Command")
     sad_command = f"""OFF ECHO;
 
@@ -85,34 +89,26 @@ Close[of];
 abort;
 """
 
-    ########################################
-    # Write the SAD command
-    ########################################
-    with open("temp_sad_rebuild_lattice.sad", "w", encoding = "utf-8") as f:
-        f.write(sad_command)
-
-    ########################################
-    # Run the process
-    ########################################
     try:
-        subprocess.run(
-            [sad_path, "temp_sad_rebuild_lattice.sad"],
-            capture_output  = True,
-            text            = True,
-            timeout         = wall_time,
-            check           = True)
-    except subprocess.TimeoutExpired:
-        print(f"SAD Twiss timed out at {wall_time}s")
-        if os.path.exists("temp_sad_rebuild_lattice.sad"):
-            os.remove("temp_sad_rebuild_lattice.sad")
-        raise
-    except subprocess.CalledProcessError as e:
-        print(f"SAD exited with non-zero status {e.returncode}")
-        print("stdout:", e.stdout)
-        print("stderr:", e.stderr)
-        if os.path.exists("temp_sad_rebuild_lattice.sad"):
-            os.remove("temp_sad_rebuild_lattice.sad")
-        raise
+        with open(cmd_file, "w", encoding = "utf-8") as f:
+            f.write(sad_command)
+
+        try:
+            subprocess.run(
+                [sad_path, cmd_file],
+                capture_output  = True,
+                text            = True,
+                timeout         = wall_time,
+                check           = True)
+        except subprocess.TimeoutExpired:
+            print(f"SAD Twiss timed out at {wall_time}s")
+            raise
+        except subprocess.CalledProcessError as e:
+            print(f"SAD exited with non-zero status {e.returncode}")
+            print("stdout:", e.stdout)
+            print("stderr:", e.stderr)
+            raise
+
     finally:
-        if os.path.exists("temp_sad_rebuild_lattice.sad"):
-            os.remove("temp_sad_rebuild_lattice.sad")
+        if os.path.exists(cmd_file):
+            os.remove(cmd_file)

--- a/sad2xs/sad_helpers/survey.py
+++ b/sad2xs/sad_helpers/survey.py
@@ -7,6 +7,7 @@
 ################################################################################
 import os
 import subprocess
+import uuid
 import numpy as np
 import tfs
 import xtrack as xt
@@ -115,6 +116,10 @@ def survey_sad(
     ########################################
     # Generate the twiss command
     ########################################
+    uid      = uuid.uuid4().hex[:12]
+    cmd_file = f"_sad_survey_{uid}.sad"
+    out_file = f"_sad_survey_{uid}.tfs"
+
     print("Creating SAD Command")
     sad_command = f"""OFF ECHO;
 
@@ -146,7 +151,7 @@ SAVE ALL;
 ! Include the survey print function
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 {generate_survey_print_function()}
-SaveSurveyFile["./temp_sad_survey.tfs"];
+SaveSurveyFile["./{out_file}"];
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! Close process
@@ -154,43 +159,32 @@ SaveSurveyFile["./temp_sad_survey.tfs"];
 abort;
 """
 
-    ########################################
-    # Write the SAD command
-    ########################################
-    with open("temp_sad_survey.sad", "w", encoding = "utf-8") as f:
-        f.write(sad_command)
-
-    ########################################
-    # Run the process
-    ########################################
     try:
-        subprocess.run(
-            [sad_path, "temp_sad_survey.sad"],
-            capture_output  = True,
-            text            = True,
-            timeout         = wall_time,
-            check           = True)
-    except subprocess.TimeoutExpired:
-        print(f"SAD Twiss timed out at {wall_time}s")
-        if os.path.exists("temp_sad_survey.sad"):
-            os.remove("temp_sad_survey.sad")
-        raise
-    except subprocess.CalledProcessError as e:
-        print(f"SAD exited with non-zero status {e.returncode}")
-        print("stdout:", e.stdout)
-        print("stderr:", e.stderr)
-        if os.path.exists("temp_sad_survey.sad"):
-            os.remove("temp_sad_survey.sad")
-        raise
-    finally:
-        if os.path.exists("temp_sad_survey.sad"):
-            os.remove("temp_sad_survey.sad")
+        with open(cmd_file, "w", encoding = "utf-8") as f:
+            f.write(sad_command)
 
-    ########################################
-    # Read the data
-    ########################################
-    sad_survey   = tfs.read("temp_sad_survey.tfs")
-    os.remove("temp_sad_survey.tfs")
+        try:
+            subprocess.run(
+                [sad_path, cmd_file],
+                capture_output  = True,
+                text            = True,
+                timeout         = wall_time,
+                check           = True)
+        except subprocess.TimeoutExpired:
+            print(f"SAD Twiss timed out at {wall_time}s")
+            raise
+        except subprocess.CalledProcessError as e:
+            print(f"SAD exited with non-zero status {e.returncode}")
+            print("stdout:", e.stdout)
+            print("stderr:", e.stderr)
+            raise
+
+        sad_survey = tfs.read(out_file)
+
+    finally:
+        for path in [cmd_file, out_file]:
+            if os.path.exists(path):
+                os.remove(path)
 
     ########################################
     # Convert the element types

--- a/sad2xs/sad_helpers/track.py
+++ b/sad2xs/sad_helpers/track.py
@@ -7,6 +7,7 @@
 ################################################################################
 import os
 import subprocess
+import uuid
 import re
 import time
 import textwrap
@@ -160,6 +161,10 @@ def track_sad(
     ########################################
     # Generate the twiss command
     ########################################
+    uid      = uuid.uuid4().hex[:12]
+    cmd_file = f"_sad_track_{uid}.sad"
+    out_file = f"_sad_track_{uid}.dat"
+
     print("Creating SAD Command")
     sad_command = f"""OFF ECHO;
 
@@ -231,7 +236,7 @@ r       = Prepend[r1, r0];
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! Save to file
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-Put[r, "temp_sad_track.dat"];
+Put[r, "{out_file}"];
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! Close process
@@ -239,7 +244,7 @@ Put[r, "temp_sad_track.dat"];
 abort;
 """
     elif turn_by_turn_monitor and not with_progress:
-        sad_command += """
+        sad_command += f"""
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! Store initial beam
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -253,7 +258,7 @@ r1 = Table[
         beam = TrackParticles[beam, 1, turn, turn];
         beam[[2]]
     ),
-    {turn, 1, turns}
+    {{turn, 1, turns}}
     ];
 WriteString[6,"TRACKING COMPLETE \\n"];
 
@@ -265,7 +270,7 @@ r = Prepend[r1, r0];
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! Save to file
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-Put[r, "temp_sad_track.dat"];
+Put[r, "{out_file}"];
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! Close process
@@ -288,7 +293,7 @@ WriteString[6,"TRACKING COMPLETE \\n"];
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! Save to file
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-Put[beam[[2]], "temp_sad_track.dat"];
+Put[beam[[2]], "{out_file}"];
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! Close process
@@ -296,7 +301,7 @@ Put[beam[[2]], "temp_sad_track.dat"];
 abort;
 """
     else:
-        sad_command += """
+        sad_command += f"""
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! Track particles
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -306,7 +311,7 @@ WriteString[6,"TRACKING COMPLETE \\n"];
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! Save to file
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-Put[beam[[2]], "temp_sad_track.dat"];
+Put[beam[[2]], "{out_file}"];
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! Close process
@@ -314,83 +319,79 @@ Put[beam[[2]], "temp_sad_track.dat"];
 abort;
 """
 
-    ########################################
-    # Write the SAD command
-    ########################################
     print("Writing SAD Command")
-    with open("temp_sad_track.sad", "w", encoding = "utf-8") as f:
-        f.write(sad_command)
-    del sad_command
+    try:
+        with open(cmd_file, "w", encoding = "utf-8") as f:
+            f.write(sad_command)
+        del sad_command
 
-    ########################################
-    # Set up progress bar
-    ########################################
-    print("Running SAD")
-    if with_progress:
-        progress_re = re.compile(r"PROGRESS:(\d+)")
-        pbar        = tqdm(total = n_turns)
-
-    ########################################
-    # Set up process
-    ########################################
-    stdout_lines    = []
-    start           = time.time()
-
-    process = subprocess.Popen(
-        [sad_path, "temp_sad_track.sad"],
-        stdout      = subprocess.PIPE,
-        stderr      = subprocess.STDOUT,
-        text        = True,
-        bufsize     = 1)
-
-    ########################################
-    # Run the process, reading lines for progress
-    ########################################
-    for line in process.stdout:                                 # type: ignore
-        stdout_lines.append(line)
-
-        if process.poll() is not None:
-            raise RuntimeError(f"Subprocess died early with code {process.returncode}")
-
-        if "TRACKING COMPLETE" in line:
-            if with_progress:
-                pbar.close()                                    # type: ignore
-            print("SAD tracking complete, writing output file")
-            break
-
-        # Check for progress lines
+        ########################################
+        # Set up progress bar
+        ########################################
+        print("Running SAD")
         if with_progress:
-            m = progress_re.search(line)                        # type: ignore
-            if m:
-                done    = int(m.group(1))
-                pbar.n  = done                                  # type: ignore
-                pbar.refresh()                                  # type: ignore
+            progress_re = re.compile(r"PROGRESS:(\d+)")
+            pbar        = tqdm(total = n_turns)
 
-        # Timeout handling
-        if time.time() - start > wall_time:
-            process.kill()
-            os.remove("temp_sad_track.sad")
-            raise TimeoutError("SAD tracking timed out")
+        ########################################
+        # Set up process
+        ########################################
+        stdout_lines    = []
+        start           = time.time()
 
-    ########################################
-    # Check the process exits correctly
-    ########################################
-    process.wait()
-    if process.returncode != 0:
-        raise RuntimeError(f"Subprocess exited with error code {process.returncode}")
+        process = subprocess.Popen(
+            [sad_path, cmd_file],
+            stdout      = subprocess.PIPE,
+            stderr      = subprocess.STDOUT,
+            text        = True,
+            bufsize     = 1)
 
-    ########################################
-    # Load the data
-    ########################################
-    print("Loading output file")
-    with open("temp_sad_track.dat", "r", encoding = "utf-8") as f:
-        raw_output  = f.read()
+        ########################################
+        # Run the process, reading lines for progress
+        ########################################
+        for line in process.stdout:                                 # type: ignore
+            stdout_lines.append(line)
 
-    ########################################
-    # Remove temporary data
-    ########################################
-    os.remove("temp_sad_track.sad")
-    os.remove("temp_sad_track.dat")
+            if process.poll() is not None:
+                raise RuntimeError(f"Subprocess died early with code {process.returncode}")
+
+            if "TRACKING COMPLETE" in line:
+                if with_progress:
+                    pbar.close()                                    # type: ignore
+                print("SAD tracking complete, writing output file")
+                break
+
+            # Check for progress lines
+            if with_progress:
+                m = progress_re.search(line)                        # type: ignore
+                if m:
+                    done    = int(m.group(1))
+                    pbar.n  = done                                  # type: ignore
+                    pbar.refresh()                                  # type: ignore
+
+            # Timeout handling
+            if time.time() - start > wall_time:
+                process.kill()
+                raise TimeoutError("SAD tracking timed out")
+
+        ########################################
+        # Check the process exits correctly
+        ########################################
+        process.wait()
+        if process.returncode != 0:
+            raise RuntimeError(f"Subprocess exited with error code {process.returncode}")
+
+        ########################################
+        # Load the data
+        ########################################
+        print("Loading output file")
+        with open(out_file, "r", encoding = "utf-8") as f:
+            raw_output  = f.read()
+
+    finally:
+        for path in [cmd_file, out_file]:
+            if os.path.exists(path):
+                os.remove(path)
 
     ########################################
     # Process the data

--- a/sad2xs/sad_helpers/twiss.py
+++ b/sad2xs/sad_helpers/twiss.py
@@ -7,6 +7,7 @@
 ################################################################################
 import os
 import subprocess
+import uuid
 import numpy as np
 import tfs
 import xtrack as xt
@@ -171,6 +172,10 @@ def twiss_sad(
     ########################################
     # Generate the twiss command
     ########################################
+    uid      = uuid.uuid4().hex[:12]
+    cmd_file = f"_sad_twiss_{uid}.sad"
+    out_file = f"_sad_twiss_{uid}.tfs"
+
     print("Creating SAD Command")
     sad_command = f"""OFF ECHO;
 
@@ -209,7 +214,7 @@ SAVE ALL;
 ! Include the twiss print function
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 {generate_twiss_print_function()}
-SaveTwissFile["./temp_sad_twiss.tfs"];
+SaveTwissFile["./{out_file}"];
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! Close process
@@ -217,43 +222,32 @@ SaveTwissFile["./temp_sad_twiss.tfs"];
 abort;
 """
 
-    ########################################
-    # Write the SAD command
-    ########################################
-    with open("temp_sad_twiss.sad", "w", encoding = "utf-8") as f:
-        f.write(sad_command)
-
-    ########################################
-    # Run the process
-    ########################################
     try:
-        subprocess.run(
-            [sad_path, "temp_sad_twiss.sad"],
-            capture_output  = True,
-            text            = True,
-            timeout         = wall_time,
-            check           = True)
-    except subprocess.TimeoutExpired:
-        print(f"SAD Twiss timed out at {wall_time}s")
-        if os.path.exists("temp_sad_twiss.sad"):
-            os.remove("temp_sad_twiss.sad")
-        raise
-    except subprocess.CalledProcessError as e:
-        print(f"SAD exited with non-zero status {e.returncode}")
-        print("stdout:", e.stdout)
-        print("stderr:", e.stderr)
-        if os.path.exists("temp_sad_twiss.sad"):
-            os.remove("temp_sad_twiss.sad")
-        raise
-    finally:
-        if os.path.exists("temp_sad_twiss.sad"):
-            os.remove("temp_sad_twiss.sad")
+        with open(cmd_file, "w", encoding = "utf-8") as f:
+            f.write(sad_command)
 
-    ########################################
-    # Read the data
-    ########################################
-    sad_twiss   = tfs.read("temp_sad_twiss.tfs")
-    os.remove("temp_sad_twiss.tfs")
+        try:
+            subprocess.run(
+                [sad_path, cmd_file],
+                capture_output  = True,
+                text            = True,
+                timeout         = wall_time,
+                check           = True)
+        except subprocess.TimeoutExpired:
+            print(f"SAD Twiss timed out at {wall_time}s")
+            raise
+        except subprocess.CalledProcessError as e:
+            print(f"SAD exited with non-zero status {e.returncode}")
+            print("stdout:", e.stdout)
+            print("stderr:", e.stderr)
+            raise
+
+        sad_twiss = tfs.read(out_file)
+
+    finally:
+        for path in [cmd_file, out_file]:
+            if os.path.exists(path):
+                os.remove(path)
 
     ########################################
     # Convert to TwissTable


### PR DESCRIPTION
## Summary

- run SAD helper subprocess utilities in isolated temporary directories
- update emit, lattice rebuild, survey, tracking, and Twiss helpers to use safe temporary paths
- remove obsolete shared-working-directory guidance from the SAD helper documentation

## Validation

- awaiting PR test checks

Closes #27