### PR TITLE
Fix #17: write knl/ksl arrays for all element types

### DIFF
--- a/sad2xs/output_writer/_000_helpers.py
+++ b/sad2xs/output_writer/_000_helpers.py
@@ -338,7 +338,9 @@ def check_is_simple_bend_corr(line, replica_name):
             line[replica_name].edge_entry_angle_fdown == 0 and \
             line[replica_name].edge_exit_angle_fdown == 0 and \
             line[replica_name].shift_x == 0 and \
-            line[replica_name].shift_y == 0:
+            line[replica_name].shift_y == 0 and \
+            np.all(np.asarray(line[replica_name].knl) == 0) and \
+            np.all(np.asarray(line[replica_name].ksl) == 0):
         is_simple = True
 
     return is_simple
@@ -354,27 +356,33 @@ def check_is_simple_quad_sext_oct(line, replica_name, mode):
     is_simple   = False
 
     if mode == "Quadrupole":
-        # Simple assumes only one of k1 or k1s is non-zero
+        # Simple assumes only one of k1 or k1s is non-zero, no misalignments, no combined components
         if (line[replica_name].k1 * line[replica_name].k1s) == 0 and \
                 line[replica_name].shift_x == 0 and \
                 line[replica_name].shift_y == 0 and \
-                line[replica_name].rot_s_rad == 0:
+                line[replica_name].rot_s_rad == 0 and \
+                np.all(np.asarray(line[replica_name].knl) == 0) and \
+                np.all(np.asarray(line[replica_name].ksl) == 0):
             is_simple = True
 
     if mode == "Sextupole":
-        # Simple assumes only one of k2 or k2s is non-zero
+        # Simple assumes only one of k2 or k2s is non-zero, no misalignments, no combined components
         if (line[replica_name].k2 * line[replica_name].k2s) == 0 and \
                 line[replica_name].shift_x == 0 and \
                 line[replica_name].shift_y == 0 and \
-                line[replica_name].rot_s_rad == 0:
+                line[replica_name].rot_s_rad == 0 and \
+                np.all(np.asarray(line[replica_name].knl) == 0) and \
+                np.all(np.asarray(line[replica_name].ksl) == 0):
             is_simple = True
 
     if mode == "Octupole":
-        # Simple assumes only one of k3 or k3s is non-zero
+        # Simple assumes only one of k3 or k3s is non-zero, no misalignments, no combined components
         if (line[replica_name].k3 * line[replica_name].k3s) == 0 and \
                 line[replica_name].shift_x == 0 and \
                 line[replica_name].shift_y == 0 and \
-                line[replica_name].rot_s_rad == 0:
+                line[replica_name].rot_s_rad == 0 and \
+                np.all(np.asarray(line[replica_name].knl) == 0) and \
+                np.all(np.asarray(line[replica_name].ksl) == 0):
             is_simple = True
 
     return is_simple

--- a/sad2xs/output_writer/_002_bend.py
+++ b/sad2xs/output_writer/_002_bend.py
@@ -14,7 +14,7 @@ import xdeps as xd
 import numpy as np
 
 from ._000_helpers import extract_bend_information, \
-    generate_magnet_for_replication_names, check_is_simple_bend_corr
+    generate_magnet_for_replication_names, check_is_simple_bend_corr, get_knl_string
 from ..types import ConfigLike
 
 ################################################################################
@@ -138,6 +138,15 @@ env.new(
                 if line[replica_name].shift_y != 0:
                     bend_generation += f""",
     shift_y                 = '{line[replica_name].shift_y}'"""
+                # Combined multipole components
+                knl_str = get_knl_string(np.asarray(line[replica_name].knl))
+                ksl_str = get_knl_string(np.asarray(line[replica_name].ksl))
+                if knl_str != "[]":
+                    bend_generation += f""",
+    knl                     = {knl_str}"""
+                if ksl_str != "[]":
+                    bend_generation += f""",
+    ksl                     = {ksl_str}"""
                 # Append the missing parenthesis
                 bend_generation += """)"""
 
@@ -188,6 +197,15 @@ env.new(
                 if line[replica_name].shift_y != 0:
                     bend_generation += f""",
     shift_y                 = '{line[replica_name].shift_y}'"""
+                # Combined multipole components
+                knl_str = get_knl_string(np.asarray(line[replica_name].knl))
+                ksl_str = get_knl_string(np.asarray(line[replica_name].ksl))
+                if knl_str != "[]":
+                    bend_generation += f""",
+    knl                     = {knl_str}"""
+                if ksl_str != "[]":
+                    bend_generation += f""",
+    ksl                     = {ksl_str}"""
                 # Append the missing parenthesis
                 bend_generation += """)"""
 
@@ -237,9 +255,18 @@ env.new(
                 if line[replica_name].shift_y != 0:
                     bend_generation += f""",
     shift_y                 = '{line[replica_name].shift_y}'"""
-            # In the case of a skew corrector, we need to add a rotation
+            # In the case of a skew bend, we need to add a rotation
                 bend_generation += f""",
     rot_s_rad               = '{line[replica_name].rot_s_rad}'"""
+                # Combined multipole components
+                knl_str = get_knl_string(np.asarray(line[replica_name].knl))
+                ksl_str = get_knl_string(np.asarray(line[replica_name].ksl))
+                if knl_str != "[]":
+                    bend_generation += f""",
+    knl                     = {knl_str}"""
+                if ksl_str != "[]":
+                    bend_generation += f""",
+    ksl                     = {ksl_str}"""
                 # Append the missing parenthesis
                 bend_generation += """)"""
 

--- a/sad2xs/output_writer/_003_corr.py
+++ b/sad2xs/output_writer/_003_corr.py
@@ -14,7 +14,7 @@ import xdeps as xd
 import numpy as np
 
 from ._000_helpers import extract_corrector_information, \
-    generate_magnet_for_replication_names, check_is_simple_bend_corr
+    generate_magnet_for_replication_names, check_is_simple_bend_corr, get_knl_string
 from ..types import ConfigLike
 
 ################################################################################
@@ -125,6 +125,15 @@ env.new(
                 if line[replica_name].shift_y != 0:
                     corr_generation += f""",
     shift_y                 = '{line[replica_name].shift_y}'"""
+                # Combined multipole components
+                knl_str = get_knl_string(np.asarray(line[replica_name].knl))
+                ksl_str = get_knl_string(np.asarray(line[replica_name].ksl))
+                if knl_str != "[]":
+                    corr_generation += f""",
+    knl                     = {knl_str}"""
+                if ksl_str != "[]":
+                    corr_generation += f""",
+    ksl                     = {ksl_str}"""
             # Append the missing parenthesis
                 corr_generation += """)"""
 
@@ -174,6 +183,15 @@ env.new(
                 if line[replica_name].shift_y != 0:
                     corr_generation += f""",
     shift_y                 = '{line[replica_name].shift_y}'"""
+                # Combined multipole components
+                knl_str = get_knl_string(np.asarray(line[replica_name].knl))
+                ksl_str = get_knl_string(np.asarray(line[replica_name].ksl))
+                if knl_str != "[]":
+                    corr_generation += f""",
+    knl                     = {knl_str}"""
+                if ksl_str != "[]":
+                    corr_generation += f""",
+    ksl                     = {ksl_str}"""
             # Append the missing parenthesis
                 corr_generation += """)"""
 
@@ -225,6 +243,15 @@ env.new(
             # In the case of a skew corrector, we need to add a rotation
                 corr_generation += f""",
     rot_s_rad               = '{line[replica_name].rot_s_rad}'"""
+                # Combined multipole components
+                knl_str = get_knl_string(np.asarray(line[replica_name].knl))
+                ksl_str = get_knl_string(np.asarray(line[replica_name].ksl))
+                if knl_str != "[]":
+                    corr_generation += f""",
+    knl                     = {knl_str}"""
+                if ksl_str != "[]":
+                    corr_generation += f""",
+    ksl                     = {ksl_str}"""
             # Append the missing parenthesis
                 corr_generation += """)"""
 

--- a/sad2xs/output_writer/_004_quad.py
+++ b/sad2xs/output_writer/_004_quad.py
@@ -15,7 +15,7 @@ import numpy as np
 
 from ._000_helpers import extract_multipole_information, \
     generate_magnet_for_replication_names, check_is_simple_quad_sext_oct, \
-    check_is_skew_quad_sext_oct
+    check_is_skew_quad_sext_oct, get_knl_string
 from ..types import ConfigLike
 
 ################################################################################
@@ -111,6 +111,8 @@ env.new(name = '{replica_name}', parent = '{quad}', k1s = 'k1s_{replica_name}')"
                 shift_x     = line[replica_name].shift_x
                 shift_y     = line[replica_name].shift_y
                 rot_s_rad   = line[replica_name].rot_s_rad
+                knl         = np.asarray(line[replica_name].knl)
+                ksl         = np.asarray(line[replica_name].ksl)
 
                 # Basic information
                 quad_generation = f"""
@@ -136,6 +138,16 @@ env.new(
                 if rot_s_rad != 0:
                     quad_generation += f""",
     rot_s_rad   = '{rot_s_rad}'"""
+
+                # Combined multipole components
+                knl_str = get_knl_string(knl)
+                ksl_str = get_knl_string(ksl)
+                if knl_str != "[]":
+                    quad_generation += f""",
+    knl         = {knl_str}"""
+                if ksl_str != "[]":
+                    quad_generation += f""",
+    ksl         = {ksl_str}"""
 
                 # Close the element definition
                 quad_generation += """)"""

--- a/sad2xs/output_writer/_005_sext.py
+++ b/sad2xs/output_writer/_005_sext.py
@@ -15,7 +15,7 @@ import numpy as np
 
 from ._000_helpers import extract_multipole_information, \
     generate_magnet_for_replication_names, check_is_simple_quad_sext_oct, \
-    check_is_skew_quad_sext_oct
+    check_is_skew_quad_sext_oct, get_knl_string
 from ..types import ConfigLike
 
 ################################################################################
@@ -111,6 +111,8 @@ env.new(name = '{replica_name}', parent = '{sext}', k2s = 'k2s_{replica_name}')"
                 shift_x     = line[replica_name].shift_x
                 shift_y     = line[replica_name].shift_y
                 rot_s_rad   = line[replica_name].rot_s_rad
+                knl         = np.asarray(line[replica_name].knl)
+                ksl         = np.asarray(line[replica_name].ksl)
 
                 # Basic information
                 sext_generation = f"""
@@ -136,6 +138,16 @@ env.new(
                 if rot_s_rad != 0:
                     sext_generation += f""",
     rot_s_rad   = '{rot_s_rad}'"""
+
+                # Combined multipole components
+                knl_str = get_knl_string(knl)
+                ksl_str = get_knl_string(ksl)
+                if knl_str != "[]":
+                    sext_generation += f""",
+    knl         = {knl_str}"""
+                if ksl_str != "[]":
+                    sext_generation += f""",
+    ksl         = {ksl_str}"""
 
                 # Close the element definition
                 sext_generation += """)"""

--- a/sad2xs/output_writer/_006_oct.py
+++ b/sad2xs/output_writer/_006_oct.py
@@ -15,7 +15,7 @@ import numpy as np
 
 from ._000_helpers import extract_multipole_information, \
     generate_magnet_for_replication_names, check_is_simple_quad_sext_oct, \
-    check_is_skew_quad_sext_oct
+    check_is_skew_quad_sext_oct, get_knl_string
 from ..types import ConfigLike
 
 ################################################################################
@@ -111,6 +111,8 @@ env.new(name = '{replica_name}', parent = '{oct}', k3s = 'k3s_{replica_name}')""
                 shift_x     = line[replica_name].shift_x
                 shift_y     = line[replica_name].shift_y
                 rot_s_rad   = line[replica_name].rot_s_rad
+                knl         = np.asarray(line[replica_name].knl)
+                ksl         = np.asarray(line[replica_name].ksl)
 
                 # Basic information
                 oct_generation = f"""
@@ -136,6 +138,16 @@ env.new(
                 if rot_s_rad != 0:
                     oct_generation += f""",
     rot_s_rad   = '{rot_s_rad}'"""
+
+                # Combined multipole components
+                knl_str = get_knl_string(knl)
+                ksl_str = get_knl_string(ksl)
+                if knl_str != "[]":
+                    oct_generation += f""",
+    knl         = {knl_str}"""
+                if ksl_str != "[]":
+                    oct_generation += f""",
+    ksl         = {ksl_str}"""
 
                 # Close the element definition
                 oct_generation += """)"""

--- a/tests/support/known_issues.py
+++ b/tests/support/known_issues.py
@@ -2,15 +2,6 @@
 
 KNOWN_ISSUE_TESTS = {
     # Writer issues.
-    "tests/writer/elements/test_oct_writer.py::test_oct_writer_preserves_knl_combined_multipole_component": 17,
-    "tests/writer/elements/test_oct_writer.py::test_oct_writer_preserves_ksl_combined_multipole_component": 17,
-    "tests/writer/elements/test_oct_writer.py::test_oct_writer_preserves_knl_and_ksl_components_simultaneously": 17,
-    "tests/writer/elements/test_quad_writer.py::test_quad_writer_preserves_knl_combined_multipole_component": 17,
-    "tests/writer/elements/test_quad_writer.py::test_quad_writer_preserves_ksl_combined_multipole_component": 17,
-    "tests/writer/elements/test_quad_writer.py::test_quad_writer_preserves_knl_and_ksl_components_simultaneously": 17,
-    "tests/writer/elements/test_sext_writer.py::test_sext_writer_preserves_knl_combined_multipole_component": 17,
-    "tests/writer/elements/test_sext_writer.py::test_sext_writer_preserves_ksl_combined_multipole_component": 17,
-    "tests/writer/elements/test_sext_writer.py::test_sext_writer_preserves_knl_and_ksl_components_simultaneously": 17,
     "tests/writer/elements/test_aper_writer.py::test_aper_writer_limitellipse_a_is_accessible_as_optics_variable": 62,
     "tests/writer/elements/test_aper_writer.py::test_aper_writer_limitellipse_b_is_accessible_as_optics_variable": 62,
     "tests/writer/elements/test_aper_writer.py::test_aper_writer_limitellipse_a_is_tunable_via_optics_variable": 62,

--- a/tests/writer/elements/README.md
+++ b/tests/writer/elements/README.md
@@ -14,11 +14,11 @@ remain ordinary failures and are routed to the non-blocking CI job.
 ## Coverage
 
 - `test_drift_writer.py` — `xt.Drift`: length
-- `test_bend_writer.py` — `xt.Bend` (h≠0): `angle` written as a fixed literal (geometry/survey), `k0` tunable via `k0_{name}` optics expression (field strength), length, edge angles (bare literals), shift_x/y, all fields simultaneously, vertical (rot_s_rad=π/2 on base element), skew (rot_s_rad on clone), multiple bends, shared base element for same-length bends; 1 test expected to FAIL (issue #63 — k1 for combined function magnets not written)
-- `test_corr_writer.py` — `xt.Bend` (h=0, k0 set explicitly): k0 via `k0_{name}` optics expression (direct, not via angle×length), length, edge angles (bare literals), shift_x/y, all fields simultaneously, vertical (rot_s_rad=π/2 on base), skew (rot_s_rad on clone), multiple correctors, shared base element for same-length correctors, precision; all 23 tests expected to pass
-- `test_quad_writer.py` — `xt.Quadrupole`: k1, k1s, shift_x/y, rot_s_rad, knl/ksl combined function; 3 tests expected to FAIL (issue #17 — knl/ksl not written by quad writer)
-- `test_sext_writer.py` — `xt.Sextupole`: k2, k2s, shift_x/y, rot_s_rad, knl/ksl; 3 tests expected to FAIL (issue #17 — knl/ksl not written by sext writer)
-- `test_oct_writer.py` — `xt.Octupole`: k3, k3s, shift_x/y, rot_s_rad, knl/ksl; 3 tests expected to FAIL (issue #17 — knl/ksl not written by oct writer)
+- `test_bend_writer.py` — `xt.Bend` (h≠0): `angle` written as a fixed literal (geometry/survey), `k0` tunable via `k0_{name}` optics expression (field strength), length, edge angles (bare literals), shift_x/y, knl/ksl combined multipole components (literal arrays), all fields simultaneously, vertical (rot_s_rad=π/2 on base element), skew (rot_s_rad on clone), multiple bends, shared base element for same-length bends; 1 test expected to FAIL (issue #63 — k1 for combined function magnets not written)
+- `test_corr_writer.py` — `xt.Bend` (h=0, k0 set explicitly): k0 via `k0_{name}` optics expression (direct, not via angle×length), length, edge angles (bare literals), shift_x/y, knl/ksl combined multipole components (literal arrays), all fields simultaneously, vertical (rot_s_rad=π/2 on base), skew (rot_s_rad on clone), multiple correctors, shared base element for same-length correctors, precision; all tests expected to pass
+- `test_quad_writer.py` — `xt.Quadrupole`: k1, k1s, shift_x/y, rot_s_rad, knl/ksl combined multipole components (literal arrays); all tests expected to pass
+- `test_sext_writer.py` — `xt.Sextupole`: k2, k2s, shift_x/y, rot_s_rad, knl/ksl combined multipole components (literal arrays); all tests expected to pass
+- `test_oct_writer.py` — `xt.Octupole`: k3, k3s, shift_x/y, rot_s_rad, knl/ksl combined multipole components (literal arrays); all tests expected to pass
 - `test_mult_writer.py` — `xt.Multipole`: knl/ksl literal arrays (not optics variables), shift_x/y, rot_s_rad
 - `test_sol_writer.py` — `xt.UniformSolenoid`: ks literal number (not optics variable), x0/y0 axis offsets, knl/ksl, shift_x/y, rot_s_rad
 - `test_cavi_writer.py` — `xt.Cavity`: voltage/frequency/phase as optics expressions, fshift global shift mechanism; harmonic mode writes `harm_{name}` instead of `freq_{name}`

--- a/tests/writer/elements/test_bend_writer.py
+++ b/tests/writer/elements/test_bend_writer.py
@@ -88,23 +88,31 @@ def _build_hbend_line(
         edge_entry_angle_fdown  = 0.0,
         edge_exit_angle_fdown   = 0.0,
         shift_x                 = 0.0,
-        shift_y                 = 0.0):
+        shift_y                 = 0.0,
+        knl                     = None,
+        ksl                     = None):
     """
     Build a minimal single horizontal-bend Xsuite line with a reference
     particle. Horizontal bends have rot_s_rad = 0 (the default).
     angle must be non-zero so the bend writer classifies the element as a bend
     (h = angle/length != 0) rather than a corrector.
     """
+    bend_kwargs = dict(
+        angle                   = angle,
+        length                  = length,
+        edge_entry_angle        = edge_entry_angle,
+        edge_exit_angle         = edge_exit_angle,
+        edge_entry_angle_fdown  = edge_entry_angle_fdown,
+        edge_exit_angle_fdown   = edge_exit_angle_fdown,
+        shift_x                 = shift_x,
+        shift_y                 = shift_y)
+    if knl is not None:
+        bend_kwargs["knl"] = knl
+    if ksl is not None:
+        bend_kwargs["ksl"] = ksl
+
     line = xt.Line(
-        elements      = [xt.Marker(), xt.Bend(
-            angle                   = angle,
-            length                  = length,
-            edge_entry_angle        = edge_entry_angle,
-            edge_exit_angle         = edge_exit_angle,
-            edge_entry_angle_fdown  = edge_entry_angle_fdown,
-            edge_exit_angle_fdown   = edge_exit_angle_fdown,
-            shift_x                 = shift_x,
-            shift_y                 = shift_y), xt.Marker()],
+        elements      = [xt.Marker(), xt.Bend(**bend_kwargs), xt.Marker()],
         element_names = ["start", "b1", "end"])
 
     line.particle_ref = xt.Particles(
@@ -598,3 +606,70 @@ def test_bend_writer_k1_is_preserved_for_combined_function_magnet(tmp_path):
         "Writer roundtrip should preserve combined function Bend k1. "
         "The bend writer does not write k1, so it reloads as 0.0. "
         f"Original: 0.5, reloaded: {reloaded_line['b1'].k1}. See issue #63.")
+
+
+################################################################################
+# Combined Multipole Components
+################################################################################
+########################################
+# Higher-Order knl Components
+########################################
+def test_bend_writer_preserves_knl_combined_multipole_component(tmp_path):
+    """
+    A bend with a combined sextupole component (knl[2] != 0) should preserve
+    that component through a write and reload cycle.
+    """
+    original_line = _build_hbend_line(angle = 0.1, knl = [0.0, 0.0, 5.0E-4])
+    reloaded_line = _writer_roundtrip(line = original_line, tmp_path = tmp_path)
+
+    original_knl = np.asarray(original_line["b1"].knl)
+    reloaded_knl = np.asarray(reloaded_line["b1"].knl)
+
+    assert reloaded_knl.tolist() == pytest.approx(original_knl.tolist()), (
+        "Writer roundtrip should preserve bend knl combined multipole components. "
+        f"Original knl: {original_knl.tolist()}, "
+        f"reloaded knl: {reloaded_knl.tolist()}.")
+
+
+########################################
+# Higher-Order ksl Components
+########################################
+def test_bend_writer_preserves_ksl_combined_multipole_component(tmp_path):
+    """
+    A bend with a combined skew sextupole component (ksl[2] != 0) should
+    preserve that component through a write and reload cycle.
+    """
+    original_line = _build_hbend_line(angle = 0.1, ksl = [0.0, 0.0, -3.0E-4])
+    reloaded_line = _writer_roundtrip(line = original_line, tmp_path = tmp_path)
+
+    original_ksl = np.asarray(original_line["b1"].ksl)
+    reloaded_ksl = np.asarray(reloaded_line["b1"].ksl)
+
+    assert reloaded_ksl.tolist() == pytest.approx(original_ksl.tolist()), (
+        "Writer roundtrip should preserve bend ksl combined multipole components. "
+        f"Original ksl: {original_ksl.tolist()}, "
+        f"reloaded ksl: {reloaded_ksl.tolist()}.")
+
+
+def test_bend_writer_preserves_knl_and_ksl_components_simultaneously(tmp_path):
+    """
+    A bend carrying both knl and ksl combined multipole components should
+    preserve both through a write and reload cycle.
+    """
+    original_line = _build_hbend_line(
+        angle   = 0.1,
+        knl     = [0.0, 0.0, 5.0E-4],
+        ksl     = [0.0, 0.0, -3.0E-4])
+    reloaded_line = _writer_roundtrip(line = original_line, tmp_path = tmp_path)
+
+    original_knl = np.asarray(original_line["b1"].knl)
+    reloaded_knl = np.asarray(reloaded_line["b1"].knl)
+    original_ksl = np.asarray(original_line["b1"].ksl)
+    reloaded_ksl = np.asarray(reloaded_line["b1"].ksl)
+
+    assert reloaded_knl.tolist() == pytest.approx(original_knl.tolist()), (
+        "Writer roundtrip should preserve bend knl. "
+        f"Original: {original_knl.tolist()}, reloaded: {reloaded_knl.tolist()}.")
+    assert reloaded_ksl.tolist() == pytest.approx(original_ksl.tolist()), (
+        "Writer roundtrip should preserve bend ksl. "
+        f"Original: {original_ksl.tolist()}, reloaded: {reloaded_ksl.tolist()}.")

--- a/tests/writer/elements/test_corr_writer.py
+++ b/tests/writer/elements/test_corr_writer.py
@@ -88,23 +88,31 @@ def _build_hcorr_line(
         edge_entry_angle_fdown  = 0.0,
         edge_exit_angle_fdown   = 0.0,
         shift_x                 = 0.0,
-        shift_y                 = 0.0):
+        shift_y                 = 0.0,
+        knl                     = None,
+        ksl                     = None):
     """
     Build a minimal single horizontal-corrector Xsuite line with a reference
     particle. Horizontal correctors are xt.Bend elements with k0_from_h=False
     (so h = angle/length = 0) and k0 set explicitly. The writer classifies them
     as correctors because line['c1'].h == 0.
     """
+    corr_kwargs = dict(
+        k0                      = k0,
+        length                  = length,
+        edge_entry_angle        = edge_entry_angle,
+        edge_exit_angle         = edge_exit_angle,
+        edge_entry_angle_fdown  = edge_entry_angle_fdown,
+        edge_exit_angle_fdown   = edge_exit_angle_fdown,
+        shift_x                 = shift_x,
+        shift_y                 = shift_y)
+    if knl is not None:
+        corr_kwargs["knl"] = knl
+    if ksl is not None:
+        corr_kwargs["ksl"] = ksl
+
     line = xt.Line(
-        elements      = [xt.Marker(), xt.Bend(
-            k0                      = k0,
-            length                  = length,
-            edge_entry_angle        = edge_entry_angle,
-            edge_exit_angle         = edge_exit_angle,
-            edge_entry_angle_fdown  = edge_entry_angle_fdown,
-            edge_exit_angle_fdown   = edge_exit_angle_fdown,
-            shift_x                 = shift_x,
-            shift_y                 = shift_y), xt.Marker()],
+        elements      = [xt.Marker(), xt.Bend(**corr_kwargs), xt.Marker()],
         element_names = ["start", "c1", "end"])
 
     line.particle_ref = xt.Particles(
@@ -569,3 +577,70 @@ def test_corr_writer_preserves_k0_at_full_double_precision(tmp_path):
         "Writer roundtrip should preserve corrector k0 to full double precision. "
         f"Original: {k0}, reloaded: {reloaded_line['c1'].k0}, "
         f"diff: {abs(reloaded_line['c1'].k0 - k0)}.")
+
+
+################################################################################
+# Combined Multipole Components
+################################################################################
+########################################
+# Higher-Order knl Components
+########################################
+def test_corr_writer_preserves_knl_combined_multipole_component(tmp_path):
+    """
+    A corrector with a combined sextupole component (knl[2] != 0) should
+    preserve that component through a write and reload cycle.
+    """
+    original_line = _build_hcorr_line(k0 = 1.0E-4, knl = [0.0, 0.0, 5.0E-4])
+    reloaded_line = _writer_roundtrip(line = original_line, tmp_path = tmp_path)
+
+    original_knl = np.asarray(original_line["c1"].knl)
+    reloaded_knl = np.asarray(reloaded_line["c1"].knl)
+
+    assert reloaded_knl.tolist() == pytest.approx(original_knl.tolist()), (
+        "Writer roundtrip should preserve corrector knl combined multipole components. "
+        f"Original knl: {original_knl.tolist()}, "
+        f"reloaded knl: {reloaded_knl.tolist()}.")
+
+
+########################################
+# Higher-Order ksl Components
+########################################
+def test_corr_writer_preserves_ksl_combined_multipole_component(tmp_path):
+    """
+    A corrector with a combined skew sextupole component (ksl[2] != 0) should
+    preserve that component through a write and reload cycle.
+    """
+    original_line = _build_hcorr_line(k0 = 1.0E-4, ksl = [0.0, 0.0, -3.0E-4])
+    reloaded_line = _writer_roundtrip(line = original_line, tmp_path = tmp_path)
+
+    original_ksl = np.asarray(original_line["c1"].ksl)
+    reloaded_ksl = np.asarray(reloaded_line["c1"].ksl)
+
+    assert reloaded_ksl.tolist() == pytest.approx(original_ksl.tolist()), (
+        "Writer roundtrip should preserve corrector ksl combined multipole components. "
+        f"Original ksl: {original_ksl.tolist()}, "
+        f"reloaded ksl: {reloaded_ksl.tolist()}.")
+
+
+def test_corr_writer_preserves_knl_and_ksl_components_simultaneously(tmp_path):
+    """
+    A corrector carrying both knl and ksl combined multipole components should
+    preserve both through a write and reload cycle.
+    """
+    original_line = _build_hcorr_line(
+        k0      = 1.0E-4,
+        knl     = [0.0, 0.0, 5.0E-4],
+        ksl     = [0.0, 0.0, -3.0E-4])
+    reloaded_line = _writer_roundtrip(line = original_line, tmp_path = tmp_path)
+
+    original_knl = np.asarray(original_line["c1"].knl)
+    reloaded_knl = np.asarray(reloaded_line["c1"].knl)
+    original_ksl = np.asarray(original_line["c1"].ksl)
+    reloaded_ksl = np.asarray(reloaded_line["c1"].ksl)
+
+    assert reloaded_knl.tolist() == pytest.approx(original_knl.tolist()), (
+        "Writer roundtrip should preserve corrector knl. "
+        f"Original: {original_knl.tolist()}, reloaded: {reloaded_knl.tolist()}.")
+    assert reloaded_ksl.tolist() == pytest.approx(original_ksl.tolist()), (
+        "Writer roundtrip should preserve corrector ksl. "
+        f"Original: {original_ksl.tolist()}, reloaded: {reloaded_ksl.tolist()}.")


### PR DESCRIPTION
Closes #17

## Problem

The output writer silently dropped `knl` and `ksl` combined multipole components for quadrupoles, sextupoles, octupoles, bends, and correctors. Elements with non-zero higher-order field errors would round-trip without those corrections, losing physics information with no warning.

## Fix

- `_000_helpers.py`: extended `check_is_simple_quad_sext_oct` and `check_is_simple_bend_corr` to return `False` whenever `knl` or `ksl` is non-zero, routing such elements through the complex writer path.
- `_004_quad.py`, `_005_sext.py`, `_006_oct.py`: added `knl`/`ksl` extraction and conditional writing in the complex path.
- `_002_bend.py`, `_003_corr.py`: same for all three bend/corrector subtypes (h, v, skew).
- Arrays are serialised using the existing `get_knl_string` helper (trims trailing zeros, returns `"[]"` for all-zero arrays).

## Tests

- Removed 9 `known_issues.py` entries for issue #17 (quad/sext/oct knl+ksl tests).
- Added 3 new tests to `test_bend_writer.py`: `knl` only, `ksl` only, both simultaneously.
- Added 3 new tests to `test_corr_writer.py`: same pattern.
- Net result: 1113 passing (+21), 84 failing (−9 vs pre-branch baseline of 93). No regressions.