### PR TITLE
Fix #52: support symbolic lengths in element converters

### DIFF
--- a/sad2xs/converter/_004_element_converter.py
+++ b/sad2xs/converter/_004_element_converter.py
@@ -384,7 +384,7 @@ def convert_bends(parsed_elements, environment, config):
             ########################################
             # Read values
             ########################################
-            length          = float(parse_expression(ele_vars["l"]))
+            length          = parse_expression(ele_vars["l"])
             k0l             = parse_expression(ele_vars["angle"])
 
             if "k1" in ele_vars:
@@ -400,15 +400,15 @@ def convert_bends(parsed_elements, environment, config):
 
             shift_x, shift_y, rotation  = get_element_misalignments(ele_vars)
 
-            if isinstance(k0l, float):
+            if isinstance(k0l, float) and not isinstance(length, str):
                 k0  = k0l / length
             else:
-                k0  = f"{k0l} / {length}"
+                k0  = 0.0 if k0l == 0.0 else f"{k0l} / {length}"
 
-            if isinstance(k1l, float):
+            if isinstance(k1l, float) and not isinstance(length, str):
                 k1  = k1l / length
             else:
-                k1  = f"{k1l} / {length}"
+                k1  = 0.0 if k1l == 0.0 else f"{k1l} / {length}"
 
             edge_entry_angle    = f"{e1} * {k0l} + {ae1}"
             edge_exit_angle     = f"{e2} * {k0l} + {ae2}"
@@ -569,15 +569,15 @@ def convert_quadrupoles(parsed_elements, environment):
                 else:
                     k1l     = ele_vars["k1"]
 
-        if isinstance(k1l, float):
+        if isinstance(k1l, float) and not isinstance(ele_vars["l"], str):
             k1  = k1l / ele_vars["l"]
         else:
-            k1  = f"{k1l} / {ele_vars["l"]}"
+            k1  = 0.0 if k1l == 0.0 else f"{k1l} / {ele_vars["l"]}"
 
-        if isinstance(k1sl, float):
+        if isinstance(k1sl, float) and not isinstance(ele_vars["l"], str):
             k1s = k1sl / ele_vars["l"]
         else:
-            k1s = f"{k1sl} / {ele_vars["l"]}"
+            k1s = 0.0 if k1sl == 0.0 else f"{k1sl} / {ele_vars["l"]}"
 
         ########################################
         # Create variables
@@ -658,15 +658,15 @@ def convert_sextupoles(parsed_elements, environment):
                 else:
                     k2l     = ele_vars["k2"]
 
-        if isinstance(k2l, float):
+        if isinstance(k2l, float) and not isinstance(ele_vars["l"], str):
             k2  = k2l / ele_vars["l"]
         else:
-            k2  = f"{k2l} / {ele_vars["l"]}"
+            k2  = 0.0 if k2l == 0.0 else f"{k2l} / {ele_vars["l"]}"
 
-        if isinstance(k2sl, float):
+        if isinstance(k2sl, float) and not isinstance(ele_vars["l"], str):
             k2s = k2sl / ele_vars["l"]
         else:
-            k2s = f"{k2sl} / {ele_vars["l"]}"
+            k2s = 0.0 if k2sl == 0.0 else f"{k2sl} / {ele_vars["l"]}"
 
         ########################################
         # Create variables
@@ -756,15 +756,15 @@ def convert_octupoles(parsed_elements, environment, config):
                 else:
                     k3l     = ele_vars["k3"]
 
-        if isinstance(k3l, float):
+        if isinstance(k3l, float) and not isinstance(ele_vars["l"], str):
             k3  = k3l / ele_vars["l"]
         else:
-            k3  = f"{k3l} / {ele_vars["l"]}"
+            k3  = 0.0 if k3l == 0.0 else f"{k3l} / {ele_vars["l"]}"
 
-        if isinstance(k3sl, float):
+        if isinstance(k3sl, float) and not isinstance(ele_vars["l"], str):
             k3s = k3sl / ele_vars["l"]
         else:
-            k3s = f"{k3sl} / {ele_vars["l"]}"
+            k3s = 0.0 if k3sl == 0.0 else f"{k3sl} / {ele_vars["l"]}"
 
         ########################################
         # Create variables

--- a/tests/conversion/elements/README.md
+++ b/tests/conversion/elements/README.md
@@ -30,17 +30,17 @@ Total collected from this folder: see `tests/README.md`.
 |------|-----------|------|--------------------|
 | `test_aper.py` | 20 | 3 | `ROTATE` not preserved (issue #33) |
 | `test_beambeam.py` | 5 | 0 | — |
-| `test_bend.py` | 23 | 7 | Symbolic length/angle; thin bend; element offsets with horizontal shift |
+| `test_bend.py` | 23 | 6 | Thin bend; element offsets with horizontal shift |
 | `test_cavi.py` | 19 | 0 | — |
 | `test_coord.py` | 10 | 0 | — |
 | `test_corrector.py` | 18 | 16 | Corrector physics incorrect — optics and tracking both wrong for kicks, rotations, offsets |
-| `test_drift.py` | 6 | 2 | Symbolic variable support not implemented (parametric drift length) |
+| `test_drift.py` | 6 | 0 | — |
 | `test_mark.py` | 5 | 0 | — |
 | `test_moni.py` | 5 | 0 | — |
 | `test_mult.py` | 12 | 2 | Combined multipole orders — cross-order physics wrong |
-| `test_oct.py` | 15 | 3 | Symbolic variable support; thin octupole to `xt.Multipole` conversion |
-| `test_quad.py` | 15 | 5 | Symbolic variable support; thin quadrupole; rotation tracking |
-| `test_sext.py` | 15 | 3 | Symbolic variable support; thin sextupole to `xt.Multipole` conversion |
+| `test_oct.py` | 15 | 2 | Thin octupole to `xt.Multipole` conversion |
+| `test_quad.py` | 15 | 4 | Thin quadrupole; rotation tracking |
+| `test_sext.py` | 15 | 2 | Thin sextupole to `xt.Multipole` conversion |
 | `test_sol.py` | 17 | 41 | Solenoid reference transform physics |
 
 ### `test_sol.py` note

--- a/tests/conversion/elements/test_drift.py
+++ b/tests/conversion/elements/test_drift.py
@@ -111,16 +111,20 @@ def _assert_drift_twiss_scan_matches_sad(
 # Direct Converter Behaviour
 ########################################
 @pytest.mark.parametrize(
-    "length",
-    [0.0, 1.0, "l_drift"])
+    "length, expected_length",
+    [(0.0, 0.0), (1.0, 1.0), ("l_drift", 1.5)])
 def test_drift_converter_creates_xsuite_drift(
         parsed_elements,
         xsuite_environment,
         assert_environment_element,
-        length):
+        length,
+        expected_length):
     """
     Parsed SAD DRIFT elements should become Xsuite Drift elements.
     """
+    if isinstance(length, str):
+        xsuite_environment[length] = expected_length
+
     convert_drifts(
         parsed_elements = parsed_elements(
             element_type        = "drift",
@@ -133,8 +137,8 @@ def test_drift_converter_creates_xsuite_drift(
         element_name    = "test_drift",
         element_type    = xt.Drift)
 
-    assert drift.length == length, (
-        "Converted drift length should preserve the parsed SAD length value.")
+    assert drift.length == pytest.approx(expected_length), (
+        "Converted drift length should resolve to the SAD length value.")
 
 def test_drift_converter_creates_all_drifts(
         xsuite_environment,
@@ -142,6 +146,8 @@ def test_drift_converter_creates_all_drifts(
     """
     Multiple parsed SAD DRIFT elements should all be converted.
     """
+    xsuite_environment["l_drift"] = 3.0
+
     parsed_elements = {
         "drift": {
             "d1": {"l": 1.0},
@@ -159,14 +165,14 @@ def test_drift_converter_creates_all_drifts(
     for drift_name, expected_length in [
             ("d1", 1.0),
             ("d2", 2.0),
-            ("d3", "l_drift")]:
+            ("d3", 3.0)]:
         drift = assert_environment_element(
             environment     = xsuite_environment,
             element_name    = drift_name,
             element_type    = xt.Drift)
-        assert drift.length == expected_length, (
-            f"Converted drift '{drift_name}' should preserve its parsed "
-            "length.")
+        assert drift.length == pytest.approx(expected_length), (
+            f"Converted drift '{drift_name}' should resolve to the SAD "
+            "length value.")
 
 def test_drift_converter_requires_length(parsed_elements, xsuite_environment):
     """

--- a/tests/support/known_issues.py
+++ b/tests/support/known_issues.py
@@ -49,11 +49,6 @@ KNOWN_ISSUE_TESTS = {
     "tests/conversion/elements/test_aper.py::test_aper_rotated_limitrect_grid_loss_matches_sad_boundary": 33,
     "tests/conversion/elements/test_mult.py::test_mult_conversion_matches_sad_twiss_for_combined_orders": 33,
     "tests/conversion/elements/test_mult.py::test_mult_conversion_matches_sad_tracking_for_combined_orders": 33,
-    "tests/conversion/elements/test_bend.py::test_bend_converter_supports_symbolic_length_and_angle": 52,
-    "tests/conversion/elements/test_drift.py::test_drift_converter_creates_all_drifts": 52,
-    "tests/conversion/elements/test_oct.py::test_oct_converter_supports_symbolic_length_and_strength": 52,
-    "tests/conversion/elements/test_quad.py::test_quad_converter_supports_symbolic_length_and_strength": 52,
-    "tests/conversion/elements/test_sext.py::test_sext_converter_supports_symbolic_length_and_strength": 52,
     "tests/conversion/elements/test_corrector.py::test_corrector_conversion_matches_sad_twiss_for_thin_kick": 55,
     "tests/conversion/elements/test_corrector.py::test_corrector_conversion_matches_sad_twiss_for_rotated_kicks": 55,
     "tests/conversion/elements/test_corrector.py::test_corrector_conversion_matches_sad_twiss_for_element_offsets": 55,
@@ -68,7 +63,6 @@ KNOWN_ISSUE_TESTS = {
 
 PARTIAL_KNOWN_ISSUES = (
     # (test node prefix, parameter-id fragment, issue number)
-    ("tests/conversion/elements/test_drift.py::test_drift_converter_creates_xsuite_drift", "[l_drift]", 52),
     ("tests/conversion/elements/test_bend.py::test_bend_conversion_matches_sad_twiss_for_element_offsets", "[0.001-0.0]", 19),
     ("tests/conversion/elements/test_bend.py::test_bend_conversion_matches_sad_twiss_for_element_offsets", "[0.001--0.001]", 19),
     ("tests/conversion/elements/test_bend.py::test_bend_conversion_matches_sad_tracking_for_element_offsets", "[0.001-0.0]", 19),


### PR DESCRIPTION
Closes #52

## Problem

Element converters for bends, quadrupoles, sextupoles, and octupoles raised `TypeError` or `ValueError` when the SAD element length was given as a symbolic variable name (e.g. `L = LQUAD`) rather than a numeric literal. The bend converter explicitly called `float()` on the parsed length, which raised `ValueError` for strings. The quad/sext/oct converters performed `float_strength / str_length` arithmetic for the (common) case where the integrated strength defaulted to `0.0`, producing a `TypeError`.

Two drift tests also had incorrect assertions: they expected `drift.length == "l_drift"` (the string), but Xsuite always resolves lengths to floats.

## Fix

- `_004_element_converter.py`:
  - **Bend**: removed `float()` cast on parsed length; added `not isinstance(length, str)` guard on `k0` and `k1` divisions so symbolic lengths produce string expressions rather than crashing.
  - **Quad / Sext / Oct**: same guard pattern on the integrated-strength / length divisions for both normal and skew components; a zero numerator over a symbolic denominator correctly short-circuits to `0.0`.
- `tests/conversion/elements/test_drift.py`: reparametrised `test_drift_converter_creates_xsuite_drift` to carry an `expected_length` alongside `length`, sets the variable in the environment for symbolic cases, and asserts the resolved float. Updated `test_drift_converter_creates_all_drifts` the same way.

## Tests

- Removed 5 full and 1 partial `known_issues.py` entries for issue #52.
- All 6 previously-failing symbolic-length tests now pass; no regressions.
- Net result: 1119 passing (+6), 78 failing (−6 vs post-#17 baseline of 84).