### PR TITLE
Handle thin/zero-length magnets as Multipole elements

### DIFF
--- a/sad2xs/converter/_004_element_converter.py
+++ b/sad2xs/converter/_004_element_converter.py
@@ -387,6 +387,16 @@ def convert_bends(parsed_elements, environment, config):
             length          = parse_expression(ele_vars["l"])
             k0l             = parse_expression(ele_vars["angle"])
 
+            # Thin/zero-length bend → Multipole; hxl required for reference orbit
+            # bending and dispersion generation (without it px and dpx are wrong)
+            if isinstance(length, float) and np.isclose(length, 0.0):
+                environment.new(
+                    name    = ele_name,
+                    parent  = xt.Multipole,
+                    knl     = [k0l],
+                    hxl     = k0l)
+                continue
+
             if "k1" in ele_vars:
                 k1l         = parse_expression(ele_vars["k1"])
             if "e1" in ele_vars:
@@ -527,19 +537,43 @@ def convert_quadrupoles(parsed_elements, environment):
     for ele_name, ele_vars in quads.items():
 
         ########################################
-        # Initialise parameters
+        # Thin/zero-length element → Multipole
         ########################################
-        length      = 0.0
-        k1l         = 0.0
-        k1sl        = 0.0
+        length = parse_expression(ele_vars.get("l", 0.0))
+        if isinstance(length, float) and np.isclose(length, 0.0):
+            k1l  = parse_expression(ele_vars.get("k1", 0.0))
+            k1sl = 0.0
+            if not isinstance(k1l, float):
+                k1l = 0.0
+            shift_x, shift_y, rotation = get_element_misalignments(ele_vars)
+            if isinstance(rotation, float):
+                if np.isclose(rotation, +np.pi / 4, atol = 1E-6):
+                    k1sl = -k1l
+                    k1l  = 0.0
+                    shift_x, shift_y, rotation = get_element_misalignments(
+                        ele_vars            = ele_vars,
+                        rotation_correction = -np.pi / 4)
+                elif np.isclose(rotation, -np.pi / 4, atol = 1E-6):
+                    k1sl = +k1l
+                    k1l  = 0.0
+                    shift_x, shift_y, rotation = get_element_misalignments(
+                        ele_vars            = ele_vars,
+                        rotation_correction = +np.pi / 4)
+            environment.new(
+                name      = ele_name,
+                parent    = xt.Multipole,
+                knl       = [0.0, k1l],
+                ksl       = [0.0, k1sl],
+                shift_x   = shift_x,
+                shift_y   = shift_y,
+                rot_s_rad = rotation)
+            continue
 
         ########################################
-        # Read values
+        # Initialise parameters
         ########################################
-        if "l" in ele_vars:
-            length      = parse_expression(ele_vars["l"])
-        else:
-            raise ValueError(f"Error! Quadrupole {ele_name} missing length.")
+        k1l         = 0.0
+        k1sl        = 0.0
 
         shift_x, shift_y, rotation  = get_element_misalignments(ele_vars)
 
@@ -616,19 +650,43 @@ def convert_sextupoles(parsed_elements, environment):
     for ele_name, ele_vars in sexts.items():
 
         ########################################
-        # Initialise parameters
+        # Thin/zero-length element → Multipole
         ########################################
-        length      = 0.0
-        k2l         = 0.0
-        k2sl        = 0.0
+        length = parse_expression(ele_vars.get("l", 0.0))
+        if isinstance(length, float) and np.isclose(length, 0.0):
+            k2l  = parse_expression(ele_vars.get("k2", 0.0))
+            k2sl = 0.0
+            if not isinstance(k2l, float):
+                k2l = 0.0
+            shift_x, shift_y, rotation = get_element_misalignments(ele_vars)
+            if isinstance(rotation, float):
+                if np.isclose(rotation, +np.pi / 6, atol = 1E-6):
+                    k2sl = -k2l
+                    k2l  = 0.0
+                    shift_x, shift_y, rotation = get_element_misalignments(
+                        ele_vars            = ele_vars,
+                        rotation_correction = -np.pi / 6)
+                elif np.isclose(rotation, -np.pi / 6, atol = 1E-6):
+                    k2sl = +k2l
+                    k2l  = 0.0
+                    shift_x, shift_y, rotation = get_element_misalignments(
+                        ele_vars            = ele_vars,
+                        rotation_correction = +np.pi / 6)
+            environment.new(
+                name      = ele_name,
+                parent    = xt.Multipole,
+                knl       = [0.0, 0.0, k2l],
+                ksl       = [0.0, 0.0, k2sl],
+                shift_x   = shift_x,
+                shift_y   = shift_y,
+                rot_s_rad = rotation)
+            continue
 
         ########################################
-        # Read values
+        # Initialise parameters
         ########################################
-        if "l" in ele_vars:
-            length      = parse_expression(ele_vars["l"])
-        else:
-            raise ValueError(f"Error! Sextupole {ele_name} missing length.")
+        k2l         = 0.0
+        k2sl        = 0.0
 
         shift_x, shift_y, rotation  = get_element_misalignments(ele_vars)
 
@@ -704,29 +762,44 @@ def convert_octupoles(parsed_elements, environment, config):
 
     for ele_name, ele_vars in octs.items():
 
-        if "l" not in ele_vars:
-            # TODO: Improve the handling of this
-            if config._verbose:
-                print(f"Warning! Octupole {ele_name} missing length and installed as marker")
+        ########################################
+        # Thin/zero-length element → Multipole
+        ########################################
+        length = parse_expression(ele_vars.get("l", 0.0))
+        if isinstance(length, float) and np.isclose(length, 0.0):
+            k3l  = parse_expression(ele_vars.get("k3", 0.0))
+            k3sl = 0.0
+            if not isinstance(k3l, float):
+                k3l = 0.0
+            shift_x, shift_y, rotation = get_element_misalignments(ele_vars)
+            if isinstance(rotation, float):
+                if np.isclose(rotation, +np.pi / 8, atol = 1E-6):
+                    k3sl = -k3l
+                    k3l  = 0.0
+                    shift_x, shift_y, rotation = get_element_misalignments(
+                        ele_vars            = ele_vars,
+                        rotation_correction = -np.pi / 8)
+                elif np.isclose(rotation, -np.pi / 8, atol = 1E-6):
+                    k3sl = +k3l
+                    k3l  = 0.0
+                    shift_x, shift_y, rotation = get_element_misalignments(
+                        ele_vars            = ele_vars,
+                        rotation_correction = +np.pi / 8)
             environment.new(
-                name                = ele_name,
-                parent              = xt.Marker)
+                name      = ele_name,
+                parent    = xt.Multipole,
+                knl       = [0.0, 0.0, 0.0, k3l],
+                ksl       = [0.0, 0.0, 0.0, k3sl],
+                shift_x   = shift_x,
+                shift_y   = shift_y,
+                rot_s_rad = rotation)
             continue
 
         ########################################
         # Initialise parameters
         ########################################
-        length      = 0.0
         k3l         = 0.0
         k3sl        = 0.0
-
-        ########################################
-        # Read values
-        ########################################
-        if "l" in ele_vars:
-            length      = parse_expression(ele_vars["l"])
-        else:
-            raise ValueError(f"Error! Octupole {ele_name} missing length.")
 
         shift_x, shift_y, rotation  = get_element_misalignments(ele_vars)
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -94,7 +94,7 @@ Artifact paths should mirror the test area that produced them, for example
 
 ## Test Counts
 
-Total collected: **1184 tests** (1041 pass, 143 fail) as of the test run on
+Total collected: **1218 tests** (1148 pass, 70 fail) as of the test run on
 this branch. The breakdown by failure group is in the Known Failures section
 below. Individual folder READMEs document per-file counts.
 
@@ -106,20 +106,19 @@ Tests linked to open issues are marked during collection from the central
 mapping in `tests/support/known_issues.py`. They remain ordinary failing tests;
 the marker controls CI selection only and does not use `xfail`.
 
-**Group A — Documented writer issues:** 17 tests (16 in `writer/elements/`, 1
-in `writer/pipeline/`) that expose known writer bugs tracked as issues #17
-(knl/ksl not written for quad/sext/oct), #62 (aperture dimensions not written
-as live expressions), and #63 (k1 not written for combined-function bends).
-These tests must remain failing until the corresponding issues are fixed.
+**Group A — Documented writer issues:** 8 tests (7 in `writer/elements/`, 1
+in `writer/pipeline/`) that expose known writer bugs tracked as issues #62
+(aperture dimensions not written as live expressions) and #63 (k1 not written
+for combined-function bends). These tests must remain failing until the
+corresponding issues are fixed.
 
-**Group B — Exposing production bugs:** 126 tests across
+**Group B — Exposing production bugs:** 62 tests across
 `parser/`, `conversion/elements/`, and `conversion/pipeline/` that document
 known incorrect behaviour in the production code. These tests are the spec for
 the fix work that follows this PR. They must not be modified to pass — they are
 the record of what is broken and what needs to be done.
 
-All 143 currently failing instances are linked to open issues. Combined
-rectangular-and-elliptical aperture conversion is tracked by issue #66.
+All 70 currently failing instances are linked to open issues.
 
 Never modify a failing test to make it pass artificially. Fix the root cause.
 If you add a test that documents a known bug, record it in the relevant folder

--- a/tests/conversion/elements/README.md
+++ b/tests/conversion/elements/README.md
@@ -30,7 +30,7 @@ Total collected from this folder: see `tests/README.md`.
 |------|-----------|------|--------------------|
 | `test_aper.py` | 20 | 3 | `ROTATE` not preserved (issue #33) |
 | `test_beambeam.py` | 5 | 0 | — |
-| `test_bend.py` | 23 | 6 | Thin bend; element offsets with horizontal shift |
+| `test_bend.py` | 23 | 4 | Element offsets with horizontal shift |
 | `test_cavi.py` | 19 | 0 | — |
 | `test_coord.py` | 10 | 0 | — |
 | `test_corrector.py` | 18 | 16 | Corrector physics incorrect — optics and tracking both wrong for kicks, rotations, offsets |
@@ -38,32 +38,25 @@ Total collected from this folder: see `tests/README.md`.
 | `test_mark.py` | 5 | 0 | — |
 | `test_moni.py` | 5 | 0 | — |
 | `test_mult.py` | 12 | 2 | Combined multipole orders — cross-order physics wrong |
-| `test_oct.py` | 15 | 2 | Thin octupole to `xt.Multipole` conversion |
-| `test_quad.py` | 15 | 4 | Thin quadrupole; rotation tracking |
-| `test_sext.py` | 15 | 2 | Thin sextupole to `xt.Multipole` conversion |
-| `test_sol.py` | 17 | 41 | Solenoid reference transform physics |
+| `test_oct.py` | 18 | 0 | — |
+| `test_quad.py` | 18 | 2 | Rotation tracking (±45°) |
+| `test_sext.py` | 18 | 0 | — |
+| `test_sol.py` | 17 | 4 | Solenoid GEO exit-transform physics (issue #58) |
 
 ### `test_sol.py` note
 
-The solenoid tests are the most extensive in this folder. The `xt.Rotation` API
-migration (slice 3) is now complete, so `test_sol_bound_reference_transforms_use_current_xsuite_api`
-is no longer a known issue. 17 test functions expand to 41 failing instances at
-runtime because three parametrised functions carry a full matrix of perturbation
-types (`dxdy`, `dpx`, `dpy`, `dxdy_dpx_dpy`, `dxdy_chi1_chi2`) crossed with
-reversal modes (`forward`, `rev_in`, `rev_out`, `rev_both`). The failures document
-the production code work remaining for solenoid reference transform physics.
+The solenoid test functions are heavily parametrised. Most combinations pass
+following the `xt.Rotation` API migration (issue #19). The 4 remaining failing
+instances are:
 
-The root cause of all 41 failures is that SAD's GEO solenoid exit transforms are
-computed at runtime during `COD`/`CALC` and depend on the interior elements of the
-solenoid pair. For a GEO=1 boundary solenoid with entry transforms (DX, DPX etc.),
-SAD propagates the reference trajectory through the interior and computes what
-transforms the exit boundary solenoid needs to restore the orbit to zero. When a
-powered quadrupole sits inside the solenoid, it deflects the local trajectory such
-that the angle arriving at the exit boundary differs from the entry angle; the naive
-"inverse of entry transforms" approximation leaves a residual angle comparable to
-`K1 * x_inside * L` and is incorrect in general. The correct exit transforms cannot
-be derived statically from the SAD file — they require running SAD's rebuild. This
-is a SAD-side computation, not a sad2xs production code gap. See issue #58.
+- `test_sol_optics_matches_sad_twiss_at_end[±0.1]` (2 instances)
+- `test_sol_reference_transform_restores_design_orbit_at_end[out-dxdy]` and
+  `[out-dxdy_dpx_dpy]` (2 instances)
+
+The root cause is that SAD's GEO solenoid exit transforms are computed at
+runtime during `COD`/`CALC` and depend on the interior elements of the solenoid
+pair. The correct exit transforms cannot be derived statically from the SAD file
+— they require running SAD's rebuild. See issue #58.
 
 ### `test_corrector.py` note
 

--- a/tests/conversion/elements/test_oct.py
+++ b/tests/conversion/elements/test_oct.py
@@ -515,6 +515,119 @@ def test_oct_converter_converts_thin_octupole_to_multipole(
     assert multipole.knl[3] == pytest.approx(0.1), (
         "Thin OCT K3 should be preserved as integrated knl[3].")
 
+def test_oct_converter_thin_element_preserves_offsets_and_rotation(
+        parsed_elements,
+        xsuite_environment,
+        sad2xs_config,
+        assert_environment_element):
+    """
+    Thin SAD OCT DX, DY, and ROTATE should map to Xsuite Multipole fields.
+    """
+    convert_octupoles(
+        parsed_elements = parsed_elements(
+            element_type        = "oct",
+            element_name        = "test_oct",
+            element_variables   = {
+                "k3":       0.1,
+                "dx":       1.0E-3,
+                "dy":       -2.0E-3,
+                "rotate":   0.125,
+            }),
+        environment     = xsuite_environment,
+        config          = sad2xs_config)
+
+    multipole = assert_environment_element(
+        environment     = xsuite_environment,
+        element_name    = "test_oct",
+        element_type    = xt.Multipole)
+
+    assert multipole.shift_x == pytest.approx(1.0E-3), (
+        "Thin OCT DX should be preserved as Xsuite shift_x.")
+    assert multipole.shift_y == pytest.approx(-2.0E-3), (
+        "Thin OCT DY should be preserved as Xsuite shift_y.")
+    assert multipole.rot_s_rad == pytest.approx(-0.125), (
+        "Thin OCT ROTATE should apply the SAD-to-Xsuite rotation sign.")
+
+@pytest.mark.parametrize(
+    "sad_rotation, expected_knl3, expected_ksl3",
+    [
+        (+np.pi / 8, 0.0, +0.1),
+        (-np.pi / 8, 0.0, -0.1),
+    ])
+def test_oct_converter_thin_element_maps_22p5_degree_rotations_to_skew_strength(
+        parsed_elements,
+        xsuite_environment,
+        sad2xs_config,
+        assert_environment_element,
+        sad_rotation,
+        expected_knl3,
+        expected_ksl3):
+    """
+    22.5 degree rotated thin SAD OCT elements should convert to pure skew kicks.
+    """
+    convert_octupoles(
+        parsed_elements = parsed_elements(
+            element_type        = "oct",
+            element_name        = "test_oct",
+            element_variables   = {
+                "k3":       0.1,
+                "rotate":   sad_rotation,
+            }),
+        environment     = xsuite_environment,
+        config          = sad2xs_config)
+
+    multipole = assert_environment_element(
+        environment     = xsuite_environment,
+        element_name    = "test_oct",
+        element_type    = xt.Multipole)
+
+    assert multipole.knl[3] == pytest.approx(expected_knl3), (
+        "22.5 degree rotated thin OCT should not retain normal knl[3] kick.")
+    assert multipole.ksl[3] == pytest.approx(expected_ksl3), (
+        "22.5 degree rotated thin OCT should map K3 to integrated ksl[3].")
+    assert multipole.rot_s_rad == pytest.approx(0.0), (
+        "Pure skew thin OCT conversion should remove the residual rotation.")
+
+@pytest.mark.parametrize(
+    "sad_rotation",
+    [
+        +np.pi / 8 - 0.01,
+        +np.pi / 8 + 0.01,
+        -np.pi / 8 - 0.01,
+        -np.pi / 8 + 0.01,
+    ])
+def test_oct_converter_thin_element_near_22p5_degree_rotations_remain_explicit_rotations(
+        parsed_elements,
+        xsuite_environment,
+        sad2xs_config,
+        assert_environment_element,
+        sad_rotation):
+    """
+    Near-22.5-degree rotated thin SAD OCT should not trigger the skew shortcut.
+    """
+    convert_octupoles(
+        parsed_elements = parsed_elements(
+            element_type        = "oct",
+            element_name        = "test_oct",
+            element_variables   = {
+                "k3":       0.1,
+                "rotate":   sad_rotation,
+            }),
+        environment     = xsuite_environment,
+        config          = sad2xs_config)
+
+    multipole = assert_environment_element(
+        environment     = xsuite_environment,
+        element_name    = "test_oct",
+        element_type    = xt.Multipole)
+
+    assert multipole.knl[3] == pytest.approx(0.1), (
+        "Near-22.5-degree thin OCT should retain normal integrated kick.")
+    assert multipole.ksl[3] == pytest.approx(0.0), (
+        "Near-22.5-degree thin OCT should not be rewritten as pure skew.")
+    assert multipole.rot_s_rad == pytest.approx(-sad_rotation), (
+        "Near-22.5-degree thin OCT should remain an explicit Xsuite rotation.")
+
 ########################################
 # Pipeline Behaviour
 ########################################

--- a/tests/conversion/elements/test_quad.py
+++ b/tests/conversion/elements/test_quad.py
@@ -497,6 +497,113 @@ def test_quad_converter_converts_thin_quadrupole_to_multipole(
     assert multipole.knl[1] == pytest.approx(0.1), (
         "Thin QUAD K1 should be preserved as integrated knl[1].")
 
+def test_quad_converter_thin_element_preserves_offsets_and_rotation(
+        parsed_elements,
+        xsuite_environment,
+        assert_environment_element):
+    """
+    Thin SAD QUAD DX, DY, and ROTATE should map to Xsuite Multipole fields.
+    """
+    convert_quadrupoles(
+        parsed_elements = parsed_elements(
+            element_type        = "quad",
+            element_name        = "test_quad",
+            element_variables   = {
+                "k1":       0.1,
+                "dx":       1.0E-3,
+                "dy":       -2.0E-3,
+                "rotate":   0.125,
+            }),
+        environment     = xsuite_environment)
+
+    multipole = assert_environment_element(
+        environment     = xsuite_environment,
+        element_name    = "test_quad",
+        element_type    = xt.Multipole)
+
+    assert multipole.shift_x == pytest.approx(1.0E-3), (
+        "Thin QUAD DX should be preserved as Xsuite shift_x.")
+    assert multipole.shift_y == pytest.approx(-2.0E-3), (
+        "Thin QUAD DY should be preserved as Xsuite shift_y.")
+    assert multipole.rot_s_rad == pytest.approx(-0.125), (
+        "Thin QUAD ROTATE should apply the SAD-to-Xsuite rotation sign.")
+
+@pytest.mark.parametrize(
+    "sad_rotation, expected_knl1, expected_ksl1",
+    [
+        (+np.pi / 4, 0.0, +0.1),
+        (-np.pi / 4, 0.0, -0.1),
+    ])
+def test_quad_converter_thin_element_maps_45_degree_rotations_to_skew_strength(
+        parsed_elements,
+        xsuite_environment,
+        assert_environment_element,
+        sad_rotation,
+        expected_knl1,
+        expected_ksl1):
+    """
+    45 degree rotated thin SAD QUAD elements should convert to pure skew kicks.
+    """
+    convert_quadrupoles(
+        parsed_elements = parsed_elements(
+            element_type        = "quad",
+            element_name        = "test_quad",
+            element_variables   = {
+                "k1":       0.1,
+                "rotate":   sad_rotation,
+            }),
+        environment     = xsuite_environment)
+
+    multipole = assert_environment_element(
+        environment     = xsuite_environment,
+        element_name    = "test_quad",
+        element_type    = xt.Multipole)
+
+    assert multipole.knl[1] == pytest.approx(expected_knl1), (
+        "45 degree rotated thin QUAD should not retain normal knl[1] kick.")
+    assert multipole.ksl[1] == pytest.approx(expected_ksl1), (
+        "45 degree rotated thin QUAD should map K1 to integrated ksl[1].")
+    assert multipole.rot_s_rad == pytest.approx(0.0), (
+        "Pure skew thin QUAD conversion should remove the residual rotation.")
+
+@pytest.mark.parametrize(
+    "sad_rotation",
+    [
+        +np.pi / 4 - 0.01,
+        +np.pi / 4 + 0.01,
+        -np.pi / 4 - 0.01,
+        -np.pi / 4 + 0.01,
+    ])
+def test_quad_converter_thin_element_near_45_degree_rotations_remain_explicit_rotations(
+        parsed_elements,
+        xsuite_environment,
+        assert_environment_element,
+        sad_rotation):
+    """
+    Near-45-degree rotated thin SAD QUAD should not trigger the skew shortcut.
+    """
+    convert_quadrupoles(
+        parsed_elements = parsed_elements(
+            element_type        = "quad",
+            element_name        = "test_quad",
+            element_variables   = {
+                "k1":       0.1,
+                "rotate":   sad_rotation,
+            }),
+        environment     = xsuite_environment)
+
+    multipole = assert_environment_element(
+        environment     = xsuite_environment,
+        element_name    = "test_quad",
+        element_type    = xt.Multipole)
+
+    assert multipole.knl[1] == pytest.approx(0.1), (
+        "Near-45-degree thin QUAD should retain normal integrated kick.")
+    assert multipole.ksl[1] == pytest.approx(0.0), (
+        "Near-45-degree thin QUAD should not be rewritten as pure skew.")
+    assert multipole.rot_s_rad == pytest.approx(-sad_rotation), (
+        "Near-45-degree thin QUAD should remain an explicit Xsuite rotation.")
+
 ########################################
 # Pipeline Behaviour
 ########################################

--- a/tests/conversion/elements/test_sext.py
+++ b/tests/conversion/elements/test_sext.py
@@ -497,6 +497,113 @@ def test_sext_converter_converts_thin_sextupole_to_multipole(
     assert multipole.knl[2] == pytest.approx(0.1), (
         "Thin SEXT K2 should be preserved as integrated knl[2].")
 
+def test_sext_converter_thin_element_preserves_offsets_and_rotation(
+        parsed_elements,
+        xsuite_environment,
+        assert_environment_element):
+    """
+    Thin SAD SEXT DX, DY, and ROTATE should map to Xsuite Multipole fields.
+    """
+    convert_sextupoles(
+        parsed_elements = parsed_elements(
+            element_type        = "sext",
+            element_name        = "test_sext",
+            element_variables   = {
+                "k2":       0.1,
+                "dx":       1.0E-3,
+                "dy":       -2.0E-3,
+                "rotate":   0.125,
+            }),
+        environment     = xsuite_environment)
+
+    multipole = assert_environment_element(
+        environment     = xsuite_environment,
+        element_name    = "test_sext",
+        element_type    = xt.Multipole)
+
+    assert multipole.shift_x == pytest.approx(1.0E-3), (
+        "Thin SEXT DX should be preserved as Xsuite shift_x.")
+    assert multipole.shift_y == pytest.approx(-2.0E-3), (
+        "Thin SEXT DY should be preserved as Xsuite shift_y.")
+    assert multipole.rot_s_rad == pytest.approx(-0.125), (
+        "Thin SEXT ROTATE should apply the SAD-to-Xsuite rotation sign.")
+
+@pytest.mark.parametrize(
+    "sad_rotation, expected_knl2, expected_ksl2",
+    [
+        (+np.pi / 6, 0.0, +0.1),
+        (-np.pi / 6, 0.0, -0.1),
+    ])
+def test_sext_converter_thin_element_maps_30_degree_rotations_to_skew_strength(
+        parsed_elements,
+        xsuite_environment,
+        assert_environment_element,
+        sad_rotation,
+        expected_knl2,
+        expected_ksl2):
+    """
+    30 degree rotated thin SAD SEXT elements should convert to pure skew kicks.
+    """
+    convert_sextupoles(
+        parsed_elements = parsed_elements(
+            element_type        = "sext",
+            element_name        = "test_sext",
+            element_variables   = {
+                "k2":       0.1,
+                "rotate":   sad_rotation,
+            }),
+        environment     = xsuite_environment)
+
+    multipole = assert_environment_element(
+        environment     = xsuite_environment,
+        element_name    = "test_sext",
+        element_type    = xt.Multipole)
+
+    assert multipole.knl[2] == pytest.approx(expected_knl2), (
+        "30 degree rotated thin SEXT should not retain normal knl[2] kick.")
+    assert multipole.ksl[2] == pytest.approx(expected_ksl2), (
+        "30 degree rotated thin SEXT should map K2 to integrated ksl[2].")
+    assert multipole.rot_s_rad == pytest.approx(0.0), (
+        "Pure skew thin SEXT conversion should remove the residual rotation.")
+
+@pytest.mark.parametrize(
+    "sad_rotation",
+    [
+        +np.pi / 6 - 0.01,
+        +np.pi / 6 + 0.01,
+        -np.pi / 6 - 0.01,
+        -np.pi / 6 + 0.01,
+    ])
+def test_sext_converter_thin_element_near_30_degree_rotations_remain_explicit_rotations(
+        parsed_elements,
+        xsuite_environment,
+        assert_environment_element,
+        sad_rotation):
+    """
+    Near-30-degree rotated thin SAD SEXT should not trigger the skew shortcut.
+    """
+    convert_sextupoles(
+        parsed_elements = parsed_elements(
+            element_type        = "sext",
+            element_name        = "test_sext",
+            element_variables   = {
+                "k2":       0.1,
+                "rotate":   sad_rotation,
+            }),
+        environment     = xsuite_environment)
+
+    multipole = assert_environment_element(
+        environment     = xsuite_environment,
+        element_name    = "test_sext",
+        element_type    = xt.Multipole)
+
+    assert multipole.knl[2] == pytest.approx(0.1), (
+        "Near-30-degree thin SEXT should retain normal integrated kick.")
+    assert multipole.ksl[2] == pytest.approx(0.0), (
+        "Near-30-degree thin SEXT should not be rewritten as pure skew.")
+    assert multipole.rot_s_rad == pytest.approx(-sad_rotation), (
+        "Near-30-degree thin SEXT should remain an explicit Xsuite rotation.")
+
 ########################################
 # Pipeline Behaviour
 ########################################

--- a/tests/support/known_issues.py
+++ b/tests/support/known_issues.py
@@ -12,11 +12,6 @@ KNOWN_ISSUE_TESTS = {
     "tests/writer/pipeline/test_line_roundtrip.py::test_writer_roundtrip_preserves_supported_line_contract": 63,
 
     # Thin elements and current Xsuite API migration.
-    "tests/conversion/elements/test_bend.py::test_bend_conversion_matches_sad_twiss_for_thin_bend": 18,
-    "tests/conversion/elements/test_bend.py::test_bend_conversion_matches_sad_tracking_for_thin_bend": 18,
-    "tests/conversion/elements/test_oct.py::test_oct_converter_converts_thin_octupole_to_multipole": 18,
-    "tests/conversion/elements/test_quad.py::test_quad_converter_converts_thin_quadrupole_to_multipole": 18,
-    "tests/conversion/elements/test_sext.py::test_sext_converter_converts_thin_sextupole_to_multipole": 18,
     # Parser and expression handling.
     "tests/parser/test_errors.py::test_invalid_deferred_expression_syntax_raises_clear_error": 22,
     "tests/parser/test_errors.py::test_malformed_line_missing_equals_raises_clear_error": 22,


### PR DESCRIPTION
## Summary

- Thin (zero-length) QUAD, SEXT, and OCT elements now produce `xt.Multipole` instead of raising `ZeroDivisionError` (divide by length) or silently creating `xt.Marker`
- Thin BEND now produces `xt.Multipole` with `hxl=k0l`, ensuring on-orbit `Δpx=0` and correct dispersion generation; without `hxl` the reference orbit bending and `dpx` were both wrong
- Misalignments (`DX`, `DY`) and `ROTATE` are threaded through all thin paths, mirroring the thick element behaviour
- ±π/4 (quad), ±π/6 (sext), ±π/8 (oct) rotations are converted to `ksl` in thin paths, consistent with the thick element convention
- Removes the silent `xt.Marker` fallback for OCT with no length (Issue #56)
- Removes 5 `known_issue` entries for #18 and #56 — all those tests now pass
- Adds 21 new test instances covering thin element offsets, explicit rotations, and ±π/n skew conversion for QUAD, SEXT, and OCT

Closes #18
Closes #56

## Test plan

- [ ] `test_quad_converter_converts_thin_quadrupole_to_multipole` — was crashing with `ZeroDivisionError`, now passes
- [ ] `test_sext_converter_converts_thin_sextupole_to_multipole` — was crashing with `ZeroDivisionError`, now passes
- [ ] `test_oct_converter_converts_thin_octupole_to_multipole` — was creating `xt.Marker` silently, now passes
- [ ] `test_bend_conversion_matches_sad_twiss_for_thin_bend` and `test_bend_conversion_matches_sad_tracking_for_thin_bend` — were failing with wrong `px`/`dpx`, now pass
- [ ] New thin offset/rotation/skew tests for quad, sext, oct — all pass
- [ ] 70 remaining failures are all pre-existing known issues; no regressions